### PR TITLE
Update Dependencies and Update SQL Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 2.0.4
+
+### Component Changes
+
+- Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
+- Upgrade NumPy from 1.22.3 to 1.23.2
+- Upgrade pytz from 2022.1 to 2022.2.1
+
+### Application Changes
+
+- Update SQL queries in panelists and shows reports to be compatible with the MySQL flag `ONLY_FULL_GROUP_BY`
+
 ## 2.0.3
 
 ### Application Changes
@@ -15,7 +27,7 @@
 
 ### Component Changes
 
-- Upgrade Flask to 2.2.0
+- Upgrade Flask from 2.1.3 to 2.2.0
 
 ## 2.0.1
 

--- a/app/panelists/reports/debut_by_year.py
+++ b/app/panelists/reports/debut_by_year.py
@@ -21,7 +21,7 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> List[in
     query = (
         "SELECT DISTINCT YEAR(showdate) AS year "
         "FROM ww_shows "
-        "ORDER BY showdate ASC;"
+        "ORDER BY YEAR(showdate) ASC;"
     )
     cursor.execute(
         query,
@@ -114,7 +114,7 @@ def retrieve_panelists_first_shows(
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelist "
+        "GROUP BY p.panelistid "
         "ORDER BY MIN(s.showdate) ASC;"
     )
     cursor.execute(

--- a/app/panelists/reports/perfect_scores.py
+++ b/app/panelists/reports/perfect_scores.py
@@ -21,7 +21,8 @@ def retrieve_perfect_score_counts(
 
     cursor = database_connection.cursor(named_tuple=True)
     query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(p.panelist) AS count "
+        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
+        "COUNT(p.panelist) AS count "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
@@ -45,7 +46,8 @@ def retrieve_perfect_score_counts(
         }
 
     query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(p.panelist) AS count "
+        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
+        "COUNT(p.panelist) AS count "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "

--- a/app/panelists/reports/single_appearance.py
+++ b/app/panelists/reports/single_appearance.py
@@ -24,7 +24,7 @@ def retrieve_single_appearances(
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE pm.showpnlmapid IN ( "
-        "SELECT pm.showpnlmapid "
+        "SELECT ANY_VALUE(pm.showpnlmapid) "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -110,7 +110,7 @@ def retrieve_shows_all_high_scoring(
         "FROM ww_showpnlmap pm "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY s.showdate "
+        "GROUP BY s.showid "
         "HAVING SUM(pm.panelistscore) >= 50 "
         "ORDER BY SUM(pm.panelistscore) DESC, s.showdate DESC;"
     )
@@ -149,7 +149,7 @@ def retrieve_shows_all_low_scoring(
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
         "AND s.showdate <> '2018-10-27' "
-        "GROUP BY s.showdate "
+        "GROUP BY s.showid "
         "HAVING SUM(pm.panelistscore) < 30 "
         "ORDER BY SUM(pm.panelistscore) ASC, s.showdate DESC;"
     )

--- a/app/shows/reports/show_counts.py
+++ b/app/shows/reports/show_counts.py
@@ -19,7 +19,7 @@ def retrieve_show_counts_by_year(
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT DISTINCT YEAR(showdate) AS 'year' FROM ww_shows "
-        "ORDER BY showdate ASC;"
+        "ORDER BY YEAR(showdate) ASC;"
     )
     cursor.execute(query)
     result = cursor.fetchall()

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.0.3"
+APP_VERSION = "2.0.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ Flask==2.2.0
 Werkzeug==2.2.1
 gunicorn==20.1.0
 Markdown==3.4.1
-mysql-connector-python==8.0.28
-numpy==1.22.3
+mysql-connector-python==8.0.30
+numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.0
 Werkzeug==2.2.1
 gunicorn==20.1.0
 Markdown==3.4.1
-mysql-connector-python==8.0.28
-numpy==1.22.3
+mysql-connector-python==8.0.30
+numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1


### PR DESCRIPTION
## Component Changes

- Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
- Upgrade NumPy from 1.22.3 to 1.23.2
- Upgrade pytz from 2022.1 to 2022.2.1

## Application Changes

- Update SQL queries in panelists and shows reports to be compatible with the MySQL flag `ONLY_FULL_GROUP_BY`