### PR TITLE
Update Dependencies and Documentation, Update SQL Queries to Resolve `ONLY_FULL_GROUP_BY` Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 2.0.4
+
+### Component Changes
+
+- Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
+- Upgrade NumPy from 1.22.3 to 1.23.2
+- Upgrade pytz from 2022.1 to 2022.2.1
+
+### Application Changes
+
+- Update SQL queries in panelists and shows reports to be compatible with the MySQL flag `ONLY_FULL_GROUP_BY`
+
 ## 2.0.3
 
 ### Application Changes
@@ -15,7 +27,7 @@
 
 ### Component Changes
 
-- Upgrade Flask to 2.2.0
+- Upgrade Flask from 2.1.3 to 2.2.0
 
 ## 2.0.1
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,13 +1,9 @@
 # INSTALLING
 
-The following instructions target Ubuntu 20.04 LTS but should also apply to any
-system that uses `systemd` to install and manage services. Python 3.8 or newer
-is required and the system must already have a working installation available.
+The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses
+`systemd` to manage services. Python 3.8 or newer is required and the system must already have a working installation available.
 
-This document provides instructions on how to serve the application through
-[Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a
-front-end HTTP server. Other options are available for serving up applications
-built using Flask, but those options will not be covered here.
+This document provides instructions on how to serve the application through [Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a front-end HTTP server. Other options are available for serving up applications built using Flask, but those options will not be covered here.
 
 ## Installing the Application
 
@@ -17,8 +13,7 @@ Clone a copy of this repository to a location of your choosing by running:
 git clone https://github.com/questionlp/reports.wwdt.me_v2.git
 ```
 
-Within the new local copy of the repository, create a new virtual environment
-and install the required packages by running the following commands:
+Within the new local copy of the repository, create a new virtual environment and install the required packages by running the following commands:
 
 ```bash
 python3 -m venv venv
@@ -27,45 +22,27 @@ pip install -U pip setuptools wheel
 pip install -r requirements.txt
 ```
 
-Next, make a copy of the `config.json.dist` file and name it `config.json`.
-Edit the `config.json` file and fill in the required database connection
-information and any other settings that are specific to your environment.
+Next, make a copy of the `config.json.dist` file and name it `config.json`. Edit the `config.json` file and fill in the required database connection information and any other settings that are specific to your environment.
 
-To validate the installation, start up `gunicorn` using the following command
-while in the application root directory and with the virtual environment
-activated:
+To validate the installation, start up `gunicorn` using the following command while in the application root directory and with the virtual environment activated:
 
 ```bash
 gunicorn reports:app --reload
 ```
 
-Once started, open a browser and browse to <http://127.0.0.1:8000/>. This
-should bring up the Reports web application.
+Once started, open a browser and browse to <http://127.0.0.1:8000/>. This should bring up the Reports web application.
 
 ## MySQL sql_mode Flags
 
-The Reports web application includes SQL queries that were written to target
-MySQL 5.5 and MariaDB 10.x. Some of the queries may throw errors due to
-violation of the `sql_mode` flag `ONLY_FULL_GROUP_BY` on newer versions of MySQL.
+Earlier versions of the Reports Site application included SQL queries that were written to target MySQL 5.5 and MariaDB 10.x. Some of the queries may throw errors due to violation of the `sql_mode` flag `ONLY_FULL_GROUP_BY` on newer versions of MySQL. These SQL queries should already be updated to resolve such errors.
 
-To remove the `ONLY_FULL_GROUP_BY` flag from the global `sql_mode` variable,
-you will first need to query the current value of `sql_mode` by running:
+In case these errors persist when running older versions of the Stats API application, the `ONLY_FULL_GROUP_BY` flag needs to be removed from the global `sql_mode` variable. To verify which flags are currently set, you will first need to query the current value of `sql_mode` by running:
 
 ```sql
 select @@sql_mode;
 ```
 
-Copy the result and remove the `ONLY_FULL_GROUP_BY` flag from the string and
-run the following command to unset the flag globally until the MySQL service
-is restarted:
-
-```sql
-set global sql_mode='<flags>';
-```
-
-In order for the flag to be set on MySQL service startup, you will need to
-update the `mysqld.cnf` file on the server with the following configuration
-line:
+In order for the flag to be set on MySQL service startup, you will need to update the `mysqld.cnf` file on the server with the following configuration line and then restart the service.
 
 ```text
 sql-mode = <flags>
@@ -73,51 +50,31 @@ sql-mode = <flags>
 
 ## Configuring Gunicorn
 
-Gunicorn can take configuration options either as command line arguments or it
-can load configuration options from a `gunicorn.conf.py` file located in the
-same directory that Gunicorn is launched from.
+Gunicorn can take configuration options either as command line arguments or it can load configuration options from a `gunicorn.conf.py` file located in the same directory that Gunicorn is launched from.
 
-A template configuration file is included in the repository called
-`gunicorn.conf.py.dist`. A copy of that file should be made and named
-`gunicorn.conf.py` and the configuration options reviewed. The following
-options may need to be changed depending on the environment in which the
-application is being deployed:
+A template configuration file is included in the repository called `gunicorn.conf.py.dist`. A copy of that file should be made and named `gunicorn.conf.py` and the configuration options reviewed. The following options may need to be changed depending on the environment in which the application is being deployed:
 
 * `bind`: The template defaults to using a UNIX socket file at
-`/tmp/gunicorn-wwdtmreports.sock` as the listener. If TCP socket is preferred,
-change the value to `IP:PORT` (replacing `IP` and `PORT` with the
-appropriate IP address of the interface and TCP port to listen to)
+`/tmp/gunicorn-wwdtmreports.sock` as the listener. If TCP socket is preferred, change the value to `IP:PORT` (replacing `IP` and `PORT` with the appropriate IP address of the interface and TCP port to listen to)
 * `workers`: The number of processes that are created to handle requests.
-* `accesslog`: The file that will be used to write access log entries to.
-Change the value from a string to `None` to disable access logging if that'll
-be handled by NGINX or a front-end HTTP server.
-* `errorlog`: The file that will be used to write error log entries to.
-Change the value from a string to `None` to disable error logging (not
-recommended). The directory needs to be created before running the application.
+* `accesslog`: The file that will be used to write access log entries to. Change the value from a string to `None` to disable access logging if that'll be handled by NGINX or a front-end HTTP server.
+* `errorlog`: The file that will be used to write error log entries to. Change the value from a string to `None` to disable error logging (not recommended). The directory needs to be created before running the application.
 
-For more information on the above configuration options and other configuration
-options avaiable, check out the [Gunicorn documentation site](https://docs.gunicorn.org/en/stable/settings.html).
+For more information on the above configuration options and other configuration options avaiable, check out the [Gunicorn documentation site](https://docs.gunicorn.org/en/stable/settings.html).
 
 ## Setting up a Gunicorn systemd Service
 
-A template `systemd` service file is included in the repository named
-`gunicorn-wwdtmreports.service.dist`. That service file provides the commands and
-arguments used to start a Gunicorn instance to serve up the application. A copy
-of that template file can be modified and installed under `/etc/systemd/system`.
+A template `systemd` service file is included in the repository named `gunicorn-wwdtmreports.service.dist`. That service file provides the commands and arguments used to start a Gunicorn instance to serve up the application. A copy of that template file can be modified and installed under `/etc/systemd/system`.
 
-For this document, the service file will be installed as `gunicorn-wwdtmreports.service`
-and the service name will be `gunicorn-wwdtmreports`. The service file name, thus the
-service name, can be changed to meet your needs and requirements.
+For this document, the service file will be installed as `gunicorn-wwdtmreports.service` and the service name will be `gunicorn-wwdtmreports`. The service file name, thus the service name, can be changed to meet your needs and requirements.
 
 You will need to modify the following items in the new service file:
 
 * `User`: The user which the service will run under
 * `Group`: The group which the service will run under
-* `WorkingDirectory`: Provide the full path to the application root directory.
-**Do not** include the `app` directory in the path
+* `WorkingDirectory`: Provide the full path to the application root directory. **Do not** include the `app` directory in the path
 * `Environment`: Add the full path to the `venv/bin` directory
-* `ExecStart`: Include the full path to the `venv/bin` directory and insert
-that between `ExecStart=` and `gunicorn`
+* `ExecStart`: Include the full path to the `venv/bin` directory and insert that between `ExecStart=` and `gunicorn`
 
 Save the file and run the following commands to enable and start the new service:
 
@@ -134,13 +91,9 @@ sudo systemctl status gunicorn-wwdtmreports
 
 ## Serving the Application Through NGINX
 
-Once the service is up and running, NGINX can be configured to proxy requests
-to Gunicorn. NGINX can also be set up to cache responses and provide additional
-access controls that may not be feasible with Gunicorn.
+Once the service is up and running, NGINX can be configured to proxy requests to Gunicorn. NGINX can also be set up to cache responses and provide additional access controls that may not be feasible with Gunicorn.
 
-Add the following NGINX configuration snippet either to your base `nginx.conf`
-or to a virtual site configuration file. The configuration settings provides a
-starting point for serving up the application.
+Add the following NGINX configuration snippet either to your base `nginx.conf` or to a virtual site configuration file. The configuration settings provides a starting point for serving up the application.
 
 ```nginx
 upstream gunicorn-wwdtmreports {
@@ -159,8 +112,4 @@ server {
 }
 ```
 
-NGINX can also be configured to cache rendered pages to quickly serve up
-pages that are commonly and frequently requested. NGINX has documentation
-on configuring and enable proxy caching in their
-[ngx_http_proxy_module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
-module documentation.
+NGINX can also be configured to cache rendered pages to quickly serve up pages that are commonly and frequently requested. NGINX has documentation on configuring and enable proxy caching in their [ngx_http_proxy_module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html) module documentation.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,16 @@
 
 ## Overview
 
-Flask-based web application that serves up a collection of reports based on
-collected statistics and details for the NPR weekly quiz show
-[Wait Wait... Don't Tell Me!](http://waitwait.npr.org).
+Flask-based web application that serves up a collection of reports based on collected statistics and details for the NPR weekly quiz show [Wait Wait... Don't Tell Me!](http://waitwait.npr.org).
 
 ## Requirements
 
 - Python 3.8 or newer
-- MySQL or MariaDB database containing data from the Wait Wait... Don't Tell
-  Me! Stats Page database
+- MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Installation
 
-Refer to [INSTALLING.md](./INSTALLING.md) for information on how to set up an
-instance of this web application that can be served through NGINX and Gunicorn.
+Refer to [INSTALLING.md](./INSTALLING.md) for information on how to set up an instance of this web application that can be served through NGINX and Gunicorn.
 
 ## Changes
 
@@ -23,14 +19,10 @@ For changelogs, refer to [CHANGELOG.md](./CHANGELOG.md).
 
 ## Contributing
 
-If you would like contribute to this project, please make sure to review both
-the [Code of Conduct](./CODE_OF_CONDUCT.md) and the
-[Contributing](./CONTRIBUTING.md) documents in this repository.
+If you would like contribute to this project, please make sure to review both the [Code of Conduct](./CODE_OF_CONDUCT.md) and the [Contributing](./CONTRIBUTING.md) documents in this repository.
 
 ## License
 
-This web application is licensed under the terms of the
-[Apache License 2.0](./LICENSE).
+This web application is licensed under the terms of the [Apache License 2.0](./LICENSE).
 
-Original version of the Apache License 2.0 can also be found at:
-<http://www.apache.org/licenses/LICENSE-2.0>.
+Original version of the Apache License 2.0 can also be found at: <http://www.apache.org/licenses/LICENSE-2.0>.

--- a/app/panelists/reports/debut_by_year.py
+++ b/app/panelists/reports/debut_by_year.py
@@ -21,7 +21,7 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> List[in
     query = (
         "SELECT DISTINCT YEAR(showdate) AS year "
         "FROM ww_shows "
-        "ORDER BY showdate ASC;"
+        "ORDER BY YEAR(showdate) ASC;"
     )
     cursor.execute(
         query,
@@ -114,7 +114,7 @@ def retrieve_panelists_first_shows(
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelist "
+        "GROUP BY p.panelistid "
         "ORDER BY MIN(s.showdate) ASC;"
     )
     cursor.execute(

--- a/app/panelists/reports/perfect_scores.py
+++ b/app/panelists/reports/perfect_scores.py
@@ -21,7 +21,8 @@ def retrieve_perfect_score_counts(
 
     cursor = database_connection.cursor(named_tuple=True)
     query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(p.panelist) AS count "
+        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
+        "COUNT(p.panelist) AS count "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
@@ -45,7 +46,8 @@ def retrieve_perfect_score_counts(
         }
 
     query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(p.panelist) AS count "
+        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
+        "COUNT(p.panelist) AS count "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "

--- a/app/panelists/reports/single_appearance.py
+++ b/app/panelists/reports/single_appearance.py
@@ -24,7 +24,7 @@ def retrieve_single_appearances(
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE pm.showpnlmapid IN ( "
-        "SELECT pm.showpnlmapid "
+        "SELECT ANY_VALUE(pm.showpnlmapid) "
         "FROM ww_showpnlmap pm "
         "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
         "JOIN ww_shows s ON s.showid = pm.showid "

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -110,7 +110,7 @@ def retrieve_shows_all_high_scoring(
         "FROM ww_showpnlmap pm "
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY s.showdate "
+        "GROUP BY s.showid "
         "HAVING SUM(pm.panelistscore) >= 50 "
         "ORDER BY SUM(pm.panelistscore) DESC, s.showdate DESC;"
     )
@@ -149,7 +149,7 @@ def retrieve_shows_all_low_scoring(
         "JOIN ww_shows s ON s.showid = pm.showid "
         "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
         "AND s.showdate <> '2018-10-27' "
-        "GROUP BY s.showdate "
+        "GROUP BY s.showid "
         "HAVING SUM(pm.panelistscore) < 30 "
         "ORDER BY SUM(pm.panelistscore) ASC, s.showdate DESC;"
     )

--- a/app/shows/reports/show_counts.py
+++ b/app/shows/reports/show_counts.py
@@ -19,7 +19,7 @@ def retrieve_show_counts_by_year(
     cursor = database_connection.cursor(named_tuple=True)
     query = (
         "SELECT DISTINCT YEAR(showdate) AS 'year' FROM ww_shows "
-        "ORDER BY showdate ASC;"
+        "ORDER BY YEAR(showdate) ASC;"
     )
     cursor.execute(query)
     result = cursor.fetchall()

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.0.3"
+APP_VERSION = "2.0.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ Flask==2.2.0
 Werkzeug==2.2.1
 gunicorn==20.1.0
 Markdown==3.4.1
-mysql-connector-python==8.0.28
-numpy==1.22.3
+mysql-connector-python==8.0.30
+numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.0
 Werkzeug==2.2.1
 gunicorn==20.1.0
 Markdown==3.4.1
-mysql-connector-python==8.0.28
-numpy==1.22.3
+mysql-connector-python==8.0.30
+numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.2.1


### PR DESCRIPTION
## Component Changes

- Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
- Upgrade NumPy from 1.22.3 to 1.23.2
- Upgrade pytz from 2022.1 to 2022.2.1

## Application Changes

- Update SQL queries in panelists and shows reports to be compatible with the MySQL flag `ONLY_FULL_GROUP_BY`