### PR TITLE
Fix time_zone setting parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.0.5
+
+### Bugfix
+
+- Fix an issue where the `time_zone` configuration value was being assigned to `settings_config` twice, instead of being assigned to both `settings_config` and `database_config`
+
 ## 2.0.4
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -54,11 +54,11 @@ def load_config(
         time_zone_object, time_zone_string = utility.time_zone_parser(time_zone)
 
         settings_config["app_time_zone"] = time_zone_object
-        settings_config["time_zone"] = time_zone_string
+        database_config["time_zone"] = time_zone_string
         settings_config["time_zone"] = time_zone_string
     else:
         settings_config["app_time_zone"] = pytz.timezone("UTC")
-        settings_config["time_zone"] = "UTC"
+        database_config["time_zone"] = "UTC"
         settings_config["time_zone"] = "UTC"
 
     return {

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.0.4"
+APP_VERSION = "2.0.5"

--- a/config.json.dist
+++ b/config.json.dist
@@ -9,8 +9,7 @@
         "autocommit": true,
         "compress": false,
         "charset": "utf8mb4",
-        "collation": "utf8mb4_unicode_ci",
-        "time_zone": "UTC"
+        "collation": "utf8mb4_unicode_ci"
     },
 
     "settings": {


### PR DESCRIPTION
## Bugfix

- Fix an issue where the `time_zone` configuration value was being assigned to `settings_config` twice, instead of being assigned to both `settings_config` and `database_config`