### PR TITLE
Configuration Refactor and Panelist First Appearance Wins report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changes
 
+## 2.1.0
+
+### Application Changes
+
+- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set
+  - Default value for `time_zone` is `UTC`
+  - Default values for any URL is an empty string
+- Addition of Panelists First Appearance Wins report
+- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file
+- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation, in the page footer
+
+### Component Changes
+
+- Upgrade Flask from 2.2.0 to 2.2.2
+- Upgrade Werkzeug from 2.2.1 to 2.2.2
+- Upgrade pytz from 2022.2.1 to 2022.6
+
+### Development Changes
+
+- Upgrade flake8 from 4.0.1 to 5.0.4
+- Upgrade pycodestyle from 2.8.0 to 2.9.1
+- Upgrade pytest from 7.1.2 to 7.2.0
+- Upgrade black from 22.6.0 to 22.10.0
+
 ## 2.0.6
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,16 +53,20 @@ def create_app():
     app.jinja_env.globals["rank_map"] = RANK_MAP
     app.jinja_env.globals["rendered_at"] = utility.generate_date_time_stamp
 
-    app.jinja_env.globals["time_zone"] = app.config["app_settings"]["app_time_zone"]
-    app.jinja_env.globals["ga_property_code"] = app.config["app_settings"][
-        "ga_property_code"
-    ]
-    app.jinja_env.globals["api_url"] = app.config["app_settings"]["api_url"]
-    app.jinja_env.globals["blog_url"] = app.config["app_settings"]["blog_url"]
-    app.jinja_env.globals["graphs_url"] = app.config["app_settings"]["graphs_url"]
-    app.jinja_env.globals["repo_url"] = app.config["app_settings"]["repo_url"]
-    app.jinja_env.globals["site_url"] = app.config["app_settings"]["site_url"]
-    app.jinja_env.globals["stats_url"] = app.config["app_settings"]["stats_url"]
+    app.jinja_env.globals["time_zone"] = _config["settings"]["app_time_zone"]
+    app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
+        "ga_property_code", ""
+    )
+    app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
+    app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")
+    app.jinja_env.globals["graphs_url"] = _config["settings"].get("graphs_url", "")
+    app.jinja_env.globals["repo_url"] = _config["settings"].get("repo_url", "")
+    app.jinja_env.globals["site_url"] = _config["settings"].get("site_url", "")
+    app.jinja_env.globals["stats_url"] = _config["settings"].get("stats_url", "")
+    app.jinja_env.globals["mastodon_url"] = _config["settings"].get("mastodon_url", "")
+    app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
+        "mastodon_user", ""
+    )
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify

--- a/app/config.py
+++ b/app/config.py
@@ -7,19 +7,21 @@
 
 import json
 from typing import Any, Dict
-import pytz
 
 from . import utility
 
 
 def load_config(
-    config_file_path: str = "config.json", connection_pool_size: int = 12
+    config_file_path: str = "config.json",
+    connection_pool_size: int = 12,
+    connection_pool_name: str = "wwdtm_reports",
+    app_time_zone: str = "UTC",
 ) -> Dict[str, Dict[str, Any]]:
     with open(config_file_path, "r") as config_file:
         app_config = json.load(config_file)
 
-    database_config = app_config["database"]
-    settings_config = app_config["settings"]
+    database_config = app_config.get("database", None)
+    settings_config = app_config.get("settings", None)
 
     if "database" in app_config:
         database_config = app_config["database"]
@@ -28,16 +30,16 @@ def load_config(
         # is a ``use_pool`` key and it is set to True. Remove the key
         # after parsing through the configuration to prevent issues
         # with mysql.connector.connect()
-        if "use_pool" in database_config and database_config["use_pool"]:
-            if "pool_name" not in database_config or not database_config["pool_name"]:
-                database_config["pool_name"] = "wwdtm_graphs"
+        use_pool = database_config.get("use_pool", False)
 
-            if "pool_size" not in database_config or not database_config["pool_size"]:
-                database_config["pool_size"] = connection_pool_size
+        if use_pool:
+            pool_name = database_config.get("pool_name", connection_pool_name)
+            pool_size = database_config.get("pool_size", connection_pool_size)
+            if pool_size < connection_pool_size:
+                pool_size = connection_pool_size
 
-            if "pool_size" in database_config and database_config["pool_size"] < 8:
-                database_config["pool_size"] = 8
-
+            database_config["pool_name"] = pool_name
+            database_config["pool_size"] = pool_size
             del database_config["use_pool"]
         else:
             if "pool_name" in database_config:
@@ -49,17 +51,12 @@ def load_config(
             if "use_pool" in database_config:
                 del database_config["use_pool"]
 
-    if "time_zone" in settings_config and settings_config["time_zone"]:
-        time_zone = settings_config["time_zone"]
-        time_zone_object, time_zone_string = utility.time_zone_parser(time_zone)
-
-        settings_config["app_time_zone"] = time_zone_object
-        database_config["time_zone"] = time_zone_string
-        settings_config["time_zone"] = time_zone_string
-    else:
-        settings_config["app_time_zone"] = pytz.timezone("UTC")
-        database_config["time_zone"] = "UTC"
-        settings_config["time_zone"] = "UTC"
+    # Process time zone configuration settings
+    time_zone = settings_config.get("time_zone", app_time_zone)
+    time_zone_object, time_zone_string = utility.time_zone_parser(time_zone)
+    settings_config["app_time_zone"] = time_zone_object
+    settings_config["time_zone"] = time_zone_string
+    database_config["time_zone"] = time_zone_string
 
     return {
         "database": database_config,

--- a/app/panelists/reports/first_appearance_wins.py
+++ b/app/panelists/reports/first_appearance_wins.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2022 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+"""WWDTM Panelist First Appearance Wins"""
+from typing import Dict, List, Union
+
+from flask import current_app
+import mysql.connector
+
+
+def retrieve_panelists_first_appearance_wins(
+    database_connection: mysql.connector.connect,
+) -> Dict[str, Union[str, int]]:
+    """Returns a dictionary containing panelists that have won first
+    place or were tied for first place on their first appearance."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    # cursor = database_connection.cursor(dictionary=False)
+    # query: str = "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));"
+    # cursor.execute(
+    #    query,
+    # )
+    # _ = cursor.fetchall()
+    # cursor.close()
+
+    cursor = database_connection.cursor(named_tuple=True)
+    query = (
+        "SELECT DISTINCT p.panelistslug "
+        "FROM ww_showpnlmap pm "
+        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+        "JOIN ww_shows s ON s.showid = pm.showid "
+        "WHERE s.bestof = 0 "
+        "AND s.repeatshowid IS NULL "
+        "AND pm.showpnlrank IN ('1', '1t') "
+        "ORDER BY p.panelistslug;"
+    )
+
+    cursor.execute(
+        query,
+    )
+    result = cursor.fetchall()
+    cursor.close()
+
+    if not result:
+        return None
+
+    panelist_slugs = [panelist.panelistslug for panelist in result]
+
+    panelists = {}
+    for panelist_slug in panelist_slugs:
+        cursor = database_connection.cursor(named_tuple=True)
+        query = (
+            "SELECT p.panelist, s.showid, s.showdate, pm.panelistlrndstart, "
+            "pm.panelistlrndcorrect, pm.panelistscore, pm.showpnlrank "
+            "FROM ww_showpnlmap pm "
+            "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+            "JOIN ww_shows s ON s.showid = pm.showid "
+            "WHERE p.panelistslug = %s "
+            "AND s.bestof = 0 AND s.repeatshowid IS NULL "
+            "ORDER BY s.showdate ASC "
+            "LIMIT 1;"
+        )
+        cursor.execute(query, (panelist_slug,))
+        result = cursor.fetchone()
+        cursor.close()
+
+        if result:
+            if result.showpnlrank == "1" or result.showpnlrank == "1t":
+                panelists[panelist_slug] = {
+                    "name": result.panelist,
+                    "show_date": result.showdate.isoformat(),
+                    "start": result.panelistlrndstart,
+                    "correct": result.panelistlrndcorrect,
+                    "score": result.panelistscore,
+                    "rank": result.showpnlrank,
+                }
+
+    return panelists

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -7,6 +7,8 @@
 from flask import Blueprint, current_app, render_template, request
 import mysql.connector
 
+from app.dicts import RANK_MAP
+
 from .reports.common import retrieve_panelists
 from .reports.aggregate_scores import (
     retrieve_all_scores,
@@ -20,6 +22,7 @@ from .reports.appearances_by_year import (
 )
 from .reports.bluff_stats import retrieve_all_panelist_bluff_stats
 from .reports.debut_by_year import retrieve_show_years, panelist_debuts_by_year
+from .reports.first_appearance_wins import retrieve_panelists_first_appearance_wins
 from .reports.gender_stats import retrieve_stats_by_year_gender
 from .reports.panelist_vs_panelist import (
     retrieve_panelists as pvp_retrieve_panelists,
@@ -101,6 +104,19 @@ def debut_by_year():
     _debuts = panelist_debuts_by_year(database_connection=_database_connection)
     _database_connection.close()
     return render_template("panelists/debut-by-year.html", years=_years, debuts=_debuts)
+
+
+@blueprint.route("/first-appearance-wins")
+def first_appearance_wins():
+    """View: Panelists with First Appearance Wins"""
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _panelists = retrieve_panelists_first_appearance_wins(
+        database_connection=_database_connection
+    )
+    _database_connection.close()
+    return render_template(
+        "panelists/first-appearance-wins.html", panelists=_panelists, rank_map=RANK_MAP
+    )
 
 
 @blueprint.route("/first-most-recent-appearances")

--- a/app/panelists/templates/panelists/_reports.html
+++ b/app/panelists/templates/panelists/_reports.html
@@ -41,6 +41,20 @@
     </dd>
 
     <dt>
+        <a href="{{ url_for('panelists.first_appearance_wins') }}">First Appearance Wins</a>
+    </dt>
+    <dd>
+        This report provides a list of panelists that have won outright or were
+        tied for first place on their first appearance on the show.
+    </dd>
+    <dd>
+        Please note that the information in this report does not include
+        information for panelists that had that won on their first appearance
+        prior to January 2000. This is due to the lack of scoring information for
+        those shows.
+    </dd>
+
+    <dt>
         <a href="{{ url_for('panelists.first_most_recent_appearances') }}">First and Most Recent Appearances</a>
     </dt>
     <dd>

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}First Appearance Wins | Panelists{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('main.index') }}">Home</a></li>
+        <li><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>First Appearance Wins</h2>
+<p>
+    This report provides a list of panelists that have won outright or were
+    tied for first place on their first appearance on the show.
+</p>
+<p>
+    Please note that the information in this report does not include
+    information for panelists that had that won on their first appearance
+    prior to January 2000. This is due to the lack of scoring information for
+    those shows.
+</p>
+{% endblock synopsis %}
+
+{% block content %}
+<!-- Start Report Section -->
+<table class="pure-table pure-table-bordered">
+    <colgroup>
+        <col class="name panelist">
+        <col class="date">
+        <col class="score">
+        <col class="score">
+        <col class="score">
+        <col class="rank">
+    </colgroup>
+    <thead>
+        <tr>
+            <th>Panelist</th>
+            <th>Show Date</th>
+            <th>Start</th>
+            <th>Correct</th>
+            <th>Total Score</th>
+            <th>Rank</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for panelist in panelists %}
+        {% set panelist_info =  panelists[panelist] %}
+        <tr>
+            <td><a href="{{ stats_url }}/panelists/{{ panelist }}">{{ panelist_info.name }}</a></td>
+            <td><a href="{{ stats_url }}/shows/{{ panelist_info.show_date|replace('-', '/') }}">{{ panelist_info.show_date }}</a></td>
+            <td>{{ panelist_info.start }}</td>
+            <td>{{ panelist_info.correct }}</td>
+            <td>{{ panelist_info.score }}</td>
+            <td>{{ rank_map[panelist_info.rank] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<!-- End Report Section -->
+{% endblock content %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -45,7 +45,13 @@
 <footer>
     <div id="timestamp">R: {{ rendered_at(time_zone) }} | V: {{ app_version }}</div>
     <div id="copyright">
-        Copyright &copy; 2019&ndash;{{ current_year(time_zone) }} <a href="http://linhpham.org/">Linh Pham</a>. All rights reserved.
+        Copyright &copy; 2019&ndash;{{ current_year(time_zone) }}
+        {% if mastodon_url and mastodon_user %}
+        <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
+        {% else %}
+        <a href="https://linhpham.org/">Linh Pham</a>.
+        {% endif %}
+        All rights reserved.
     </div>
     <div id="source">Source code for this project is available on <a href="{{ repo_url }}">GitHub</a>
     under <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>.</div>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.0.6"
+APP_VERSION = "2.1.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -20,6 +20,8 @@
         "site_url": "",
         "stats_url": "",
         "ga_property_code": null,
-        "time_zone": "UTC"
+        "time_zone": "UTC",
+        "mastodon_url": "",
+        "mastodon_user": ""
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-required-version = "22.6.0"
-target-version = ["py38", "py39", "py310"]
+required-version = "22.10.0"
+target-version = ["py38", "py39", "py310", "py311"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
-flake8==4.0.1
-pycodestyle==2.8.0
-pytest==7.1.2
-black==22.6.0
+flake8==5.0.4
+pycodestyle==2.9.1
+pytest==7.2.0
+black==22.10.0
 
-Flask==2.2.0
-Werkzeug==2.2.1
+Flask==2.2.2
+Werkzeug==2.2.2
 gunicorn==20.1.0
 Markdown==3.4.1
 mysql-connector-python==8.0.30
 numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.2.1
+pytz==2022.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.2.0
-Werkzeug==2.2.1
+Flask==2.2.2
+Werkzeug==2.2.2
 gunicorn==20.1.0
 Markdown==3.4.1
 mysql-connector-python==8.0.30
 numpy==1.23.2
 python-dateutil==2.8.2
-pytz==2022.2.1
+pytz==2022.6

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2018-2022 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Testing Panelists Module and Blueprint Views"""
+from flask import Flask
 from flask.testing import FlaskClient
 import pytest
 from werkzeug.test import TestResponse
@@ -47,6 +48,14 @@ def test_debut_by_year(client: FlaskClient) -> None:
     assert response.status_code == 200
     assert b"Debut by Year" in response.data
     assert b"# of Regular Appearances" in response.data
+
+
+def test_first_appearance_wins(client: FlaskClient) -> None:
+    """Testing panelists.first_appearance_wins"""
+    response: TestResponse = client.get("/panelists/first-appearance-wins")
+    assert response.status_code == 200
+    assert b"First Appearance Win" in response.data
+    assert b"Show Date" in response.data
 
 
 def test_first_most_recent_appearances(client: FlaskClient) -> None:


### PR DESCRIPTION
## Application Changes

- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set
  - Default value for `time_zone` is `UTC`
  - Default values for any URL is an empty string
- Addition of Panelists First Appearance Wins report
- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file
- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation, in the page footer

## Component Changes

- Upgrade Flask from 2.2.0 to 2.2.2
- Upgrade Werkzeug from 2.2.1 to 2.2.2
- Upgrade pytz from 2022.2.1 to 2022.6

## Development Changes

- Upgrade flake8 from 4.0.1 to 5.0.4
- Upgrade pycodestyle from 2.8.0 to 2.9.1
- Upgrade pytest from 7.1.2 to 7.2.0
- Upgrade black from 22.6.0 to 22.10.0