### PR TITLE
Updating Flask and Werkzeug dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2.2.1
+
+### Component Changes
+
+- Upgrade Flask from 2.2.2 to 2.2.3
+- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability
+
 ## 2.2.0
 
 ### Application Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.2.0"
+APP_VERSION = "2.2.1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ pycodestyle==2.9.1
 pytest==7.2.0
 black==22.10.0
 
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 Markdown==3.4.1
 mysql-connector-python==8.0.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 Markdown==3.4.1
 mysql-connector-python==8.0.30


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 2.2.2 to 2.2.3
- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability