### PR TITLE
Fix issue with new hosts/scorekeepers without corresponding appearance entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.2.2
+
+### Application Changes
+
+- Fix an issue in which adding a new host or scorekeeper entry in the database without a corresponding appearance record would cause the Host or Scorekeeper Appearances Summary reports to throw an error
+
 ## 2.2.1
 
 ### Component Changes

--- a/app/scorekeepers/reports/appearances.py
+++ b/app/scorekeepers/reports/appearances.py
@@ -74,7 +74,10 @@ def retrieve_appearances_by_scorekeeper(
     cursor.close()
 
     if not result:
-        return None
+        return {
+            "regular": None,
+            "all": None,
+        }
 
     return {
         "regular": result.regular,
@@ -107,10 +110,15 @@ def retrieve_first_most_recent_appearances(
     if not result:
         return None
 
-    appearance_info = {
-        "first": result.min.isoformat(),
-        "most_recent": result.max.isoformat(),
-    }
+    if result.min:
+        first = result.min.isoformat()
+    else:
+        first = None
+
+    if result.max:
+        most_recent = result.max.isoformat()
+    else:
+        most_recent = None
 
     query = (
         "SELECT MIN(s.showdate) AS min, MAX(s.showdate) AS max "
@@ -120,16 +128,33 @@ def retrieve_first_most_recent_appearances(
         "WHERE sk.scorekeeperslug = %s;"
     )
     cursor.execute(query, (scorekeeper_slug,))
-    result = cursor.fetchone()
+    result_all = cursor.fetchone()
     cursor.close()
 
-    if not result:
-        return appearance_info
+    if not result_all:
+        return {
+            "first": first,
+            "most_recent": most_recent,
+            "first_all": None,
+            "most_recent_all": None,
+        }
 
-    appearance_info["first_all"] = result.min.isoformat()
-    appearance_info["most_recent_all"] = result.max.isoformat()
+    if result_all.min:
+        first_all = result_all.min.isoformat()
+    else:
+        first_all = None
 
-    return appearance_info
+    if result_all.max:
+        most_recent_all = result_all.max.isoformat()
+    else:
+        most_recent_all = None
+
+    return {
+        "first": first,
+        "most_recent": most_recent,
+        "first_all": first_all,
+        "most_recent_all": most_recent_all,
+    }
 
 
 def retrieve_appearance_summaries(

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.2.1"
+APP_VERSION = "2.2.2"


### PR DESCRIPTION
## Application Changes

- Fix an issue in which adding a new host or scorekeeper entry in the database without a corresponding appearance record would cause the Host or Scorekeeper Appearances Summary reports to throw an error