### PR TITLE
Update dependency versions and sort "All Women Panel" by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ app/static/robots.txt
 # Ignore New Relic Agent config file
 newrelic.ini
 
+# Deprecated files
+pytest.ini.old
+
 # Ignore macOS DS_Store files
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changes
 
+## 2.2.4
+
+### Application Changes
+
+- Correct sorting of "All Women Panel" report to sort by date
+
+### Component Changes
+
+- Upgrade MySQL Connector/Python from 8.0.30 to 8.0.33
+- Upgrade NumPy from 1.23.2 to 1.24.2
+- Upgrade pytz from 2022.6 to 2023.3
+- Upgrade Markdown from 3.4.1 to 3.4.3
+
+### Development Changes
+
+- Move pytest configuration from `pytest.ini` into `pyproject.toml`
+- Upgrade flake8 from 5.0.4 to 6.0.0
+- Upgrade pycodestyle from 2.9.1 to 2.10.0
+- Upgrade pytest from 7.2.0 to 7.3.1
+- Upgrade black from 22.10.0 to 23.3.0
+
 ## 2.2.3
 
 ### Component Changes

--- a/app/shows/reports/all_women_panel.py
+++ b/app/shows/reports/all_women_panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM All Women Panel Report Functions"""
 from typing import List, Dict
@@ -114,7 +114,8 @@ def retrieve_shows_all_women_panel(
         "AND s.showdate <> '2018-10-27' "
         "AND p.panelistgender = 'F' "
         "GROUP BY pm.showid "
-        "HAVING COUNT(s.showid) = 3;"
+        "HAVING COUNT(s.showid) = 3 "
+        "ORDER BY s.showdate ASC;"
     )
     cursor.execute(query)
     result = cursor.fetchall()

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Scoring Reports Functions"""
 from typing import List, Dict, Union
@@ -232,7 +232,6 @@ def retrieve_shows_panelist_score_sum_match(
 def retrieve_shows_panelist_perfect_scores(
     database_connection: mysql.connector.connect,
 ) -> List[Dict[str, Union[str, int]]]:
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.2.3"
+APP_VERSION = "2.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [tool.black]
-required-version = "22.10.0"
+required-version = "23.3.0"
 target-version = ["py38", "py39", "py310", "py311"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+filterwarnings = [
+    "ignore::DeprecationWarning:mysql.*:",
+]
+norecursedirs = [
+    ".git",
+    "venv",
+    "static",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:mysql.*:
-norecursedirs = .git venv static

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
-flake8==5.0.4
-pycodestyle==2.9.1
-pytest==7.2.0
-black==22.10.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.3.1
+black==23.3.0
 
 Flask==2.2.3
 Werkzeug==2.2.3
 gunicorn==20.1.0
-Markdown==3.4.1
-mysql-connector-python==8.0.30
-numpy==1.23.2
+Markdown==3.4.3
+mysql-connector-python==8.0.33
+numpy==1.24.2
 python-dateutil==2.8.2
-pytz==2022.6
+pytz==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Flask==2.2.3
 Werkzeug==2.2.3
 gunicorn==20.1.0
-Markdown==3.4.1
-mysql-connector-python==8.0.30
-numpy==1.23.2
+Markdown==3.4.3
+mysql-connector-python==8.0.33
+numpy==1.24.2
 python-dateutil==2.8.2
-pytz==2022.6
+pytz==2023.3


### PR DESCRIPTION
## Application Changes

- Correct sorting of "All Women Panel" report to sort by date

## Component Changes

- Upgrade MySQL Connector/Python from 8.0.30 to 8.0.33
- Upgrade NumPy from 1.23.2 to 1.24.2
- Upgrade pytz from 2022.6 to 2023.3
- Upgrade Markdown from 3.4.1 to 3.4.3

## Development Changes

- Move pytest configuration from `pytest.ini` into `pyproject.toml`
- Upgrade flake8 from 5.0.4 to 6.0.0
- Upgrade pycodestyle from 2.9.1 to 2.10.0
- Upgrade pytest from 7.2.0 to 7.3.1
- Upgrade black from 22.10.0 to 23.3.0