### PR TITLE
New Panelist Averages Scores by Year Reports and Other Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.3.0
+
+### Application Changes
+
+- Addition of Panelist Average Scores by Year report
+- Modify CSS for Panelist Appearances by Year report to correct column sizes
+- Add tooltips to each data cell in the Panelist Appearances by Year report to display the panelist name and year
+- Fix issue where printing out Panelist Appearances by Year report from cropping out the table when page scaling is reduced
+
+### Development Changes
+
+- Added tests for Panelist Average Scores by Year report
+- Update tests for Panelist Appearances by Year report
+
 ## 2.2.5
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 ### Application Changes
 
-- Addition of Panelist Average Scores by Year report
+- Addition of Panelist Average Scores by Year and Panelist Average Scores by Year: All reports
 - Modify CSS for Panelist Appearances by Year report to correct column sizes
 - Add tooltips to each data cell in the Panelist Appearances by Year report to display the panelist name and year
 - Fix issue where printing out Panelist Appearances by Year report from cropping out the table when page scaling is reduced
+- Fixed typos in dropdown menus when choosing panelists
 
 ### Development Changes
 
-- Added tests for Panelist Average Scores by Year report
-- Update tests for Panelist Appearances by Year report
+- Added tests for Panelist Average Scores by Year and Panelist Average Scores by Year: All reports
+- Updated tests for Panelist Appearances by Year and Panelist vs Panelist reports
 
 ## 2.2.5
 

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelists Average Scores Report Functions"""
-from typing import List, Dict
+from typing import List, Dict, Union
 
 import mysql.connector
 
@@ -32,6 +32,64 @@ def empty_years_average(database_connection: mysql.connector.connect) -> Dict[in
 
 
 def retrieve_panelist_yearly_average(
+    panelist_slug: str, database_connection: mysql.connector.connect
+) -> Dict[str, Union[str, List[float]]]:
+    """Retrieves panelist name, slug string and average scores for each
+    year"""
+
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    # Retrieve available panelists
+    cursor = database_connection.cursor(named_tuple=True)
+    query = """
+        SELECT panelist AS name, panelistslug AS slug
+        FROM ww_panelists
+        WHERE panelistslug = %s
+        ORDER BY panelistslug ASC;
+        """
+    cursor.execute(query, (panelist_slug,))
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    panelist = {
+        "name": result.name,
+        "slug": result.slug,
+    }
+
+    cursor = database_connection.cursor(named_tuple=True)
+    query = """
+    SELECT YEAR(s.showdate) AS year, SUM(pm.panelistscore) AS total,
+    COUNT(pm.panelistscore) AS count
+    FROM ww_showpnlmap pm
+    JOIN ww_panelists p ON p.panelistid = pm.panelistid
+    JOIN ww_shows s ON s.showid = pm.showid
+    WHERE p.panelistslug = %s
+    AND s.bestof = 0 AND s.repeatshowid IS NULL
+    AND s.showdate <> '2018-10-27'
+    GROUP BY YEAR(s.showdate)
+    ORDER BY YEAR(s.showdate) ASC
+    """
+    cursor.execute(query, (panelist["slug"],))
+    result = cursor.fetchall()
+    cursor.close()
+
+    averages = empty_years_average(database_connection=database_connection).copy()
+    if not result:
+        panelist["averages"] = averages
+
+    for row in result:
+        if row.total and row.count:
+            averages[row.year] = round(int(row.total) / int(row.count), 4)
+
+    panelist["averages"] = averages
+    return panelist
+
+
+def retrieve_all_panelists_yearly_average(
     database_connection: mysql.connector.connect,
 ) -> List[Dict]:
     """Retrieves a list of dictionaries for each panelist with panelist
@@ -44,7 +102,7 @@ def retrieve_panelist_yearly_average(
     # Retrieve available panelists
     cursor = database_connection.cursor(named_tuple=True)
     query = """
-        SELECT panelist, panelistslug
+        SELECT panelist AS name, panelistslug AS slug
         FROM ww_panelists
         WHERE panelistslug <> 'multiple'
         ORDER BY panelistslug ASC;
@@ -54,43 +112,15 @@ def retrieve_panelist_yearly_average(
     cursor.close()
 
     if not result:
-        database_connection.close()
         return None
 
     # Retrieve panelist information and calculate average scores per year
     panelists = []
     for panelist in result:
-        panelist_info = {
-            "name": panelist.panelist,
-            "slug": panelist.panelistslug,
-        }
-
-        cursor = database_connection.cursor(named_tuple=True)
-        query = """
-        SELECT YEAR(s.showdate) AS year, SUM(pm.panelistscore) AS total,
-        COUNT(pm.panelistscore) AS count
-        FROM ww_showpnlmap pm
-        JOIN ww_panelists p ON p.panelistid = pm.panelistid
-        JOIN ww_shows s ON s.showid = pm.showid
-        WHERE p.panelistslug = %s
-        AND s.bestof = 0 AND s.repeatshowid IS NULL
-        AND s.showdate <> '2018-10-27'
-        GROUP BY YEAR(s.showdate)
-        ORDER BY YEAR(s.showdate) ASC
-        """
-        cursor.execute(query, (panelist.panelistslug,))
-        result = cursor.fetchall()
-        cursor.close()
-
-        averages = empty_years_average(database_connection=database_connection).copy()
-        if not result:
-            panelist_info["averages"] = averages
-
-        for row in result:
-            if row.total and row.count:
-                averages[row.year] = round(int(row.total) / int(row.count), 4)
-
-        panelist_info["averages"] = averages
-        panelists.append(panelist_info)
+        panelists.append(
+            retrieve_panelist_yearly_average(
+                panelist.slug, database_connection=database_connection
+            )
+        )
 
     return panelists

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2023 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+"""WWDTM Panelists Average Scores Report Functions"""
+from typing import List, Dict
+
+import mysql.connector
+
+
+def empty_years_average(database_connection: mysql.connector.connect) -> Dict[int, int]:
+    """Retrieve a dictionary containing a list of available years as
+    keys and zeroes for values"""
+
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    # Retrieve available show years
+    cursor = database_connection.cursor(named_tuple=True)
+    query = """
+        SELECT DISTINCT YEAR(showdate) AS year
+        FROM ww_shows
+        ORDER BY YEAR(showdate) ASC;
+        """
+    cursor.execute(query)
+    result = cursor.fetchall()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return {row.year: 0 for row in result}
+
+
+def retrieve_panelist_yearly_average(
+    database_connection: mysql.connector.connect,
+) -> List[Dict]:
+    """Retrieves a list of dictionaries for each panelist with panelist
+    name, slug string and dictionary containing average scores for
+    each year"""
+
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    # Retrieve available panelists
+    cursor = database_connection.cursor(named_tuple=True)
+    query = """
+        SELECT panelist, panelistslug
+        FROM ww_panelists
+        WHERE panelistslug <> 'multiple'
+        ORDER BY panelistslug ASC;
+        """
+    cursor.execute(query)
+    result = cursor.fetchall()
+    cursor.close()
+
+    if not result:
+        database_connection.close()
+        return None
+
+    # Retrieve panelist information and calculate average scores per year
+    panelists = []
+    for panelist in result:
+        panelist_info = {
+            "name": panelist.panelist,
+            "slug": panelist.panelistslug,
+        }
+
+        cursor = database_connection.cursor(named_tuple=True)
+        query = """
+        SELECT YEAR(s.showdate) AS year, SUM(pm.panelistscore) AS total,
+        COUNT(pm.panelistscore) AS count
+        FROM ww_showpnlmap pm
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE p.panelistslug = %s
+        AND s.bestof = 0 AND s.repeatshowid IS NULL
+        GROUP BY YEAR(s.showdate)
+        ORDER BY YEAR(s.showdate) ASC
+        """
+        cursor.execute(query, (panelist.panelistslug,))
+        result = cursor.fetchall()
+        cursor.close()
+
+        averages = empty_years_average(database_connection=database_connection).copy()
+        if not result:
+            panelist_info["averages"] = averages
+
+        for row in result:
+            if row.total and row.count:
+                averages[row.year] = round(int(row.total) / int(row.count), 4)
+
+        panelist_info["averages"] = averages
+        panelists.append(panelist_info)
+
+    return panelists

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -74,6 +74,7 @@ def retrieve_panelist_yearly_average(
         JOIN ww_shows s ON s.showid = pm.showid
         WHERE p.panelistslug = %s
         AND s.bestof = 0 AND s.repeatshowid IS NULL
+        AND s.showdate <> '2018-10-27'
         GROUP BY YEAR(s.showdate)
         ORDER BY YEAR(s.showdate) ASC
         """

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -20,6 +20,7 @@ from .reports.appearances_by_year import (
     retrieve_all_appearance_counts,
     retrieve_all_years,
 )
+from .reports.average_scores_by_year import retrieve_panelist_yearly_average
 from .reports.bluff_stats import retrieve_all_panelist_bluff_stats
 from .reports.debut_by_year import retrieve_show_years, panelist_debuts_by_year
 from .reports.first_appearance_wins import retrieve_panelists_first_appearance_wins
@@ -83,6 +84,23 @@ def appearances_by_year():
         panelists=_panelists,
         show_years=_show_years,
     )
+
+
+@blueprint.route("/average-scores-by-year")
+def average_scores_by_year():
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    average_scores = retrieve_panelist_yearly_average(
+        database_connection=_database_connection
+    )
+    years = retrieve_all_years(database_connection=_database_connection)
+    if average_scores and years:
+        return render_template(
+            "panelists/average-scores-by-year.html",
+            average_scores=average_scores,
+            years=years,
+        )
+
+    return render_template("panelists/average-scores-by-year.html")
 
 
 @blueprint.route("/bluff-stats")

--- a/app/panelists/templates/panelists/_reports.html
+++ b/app/panelists/templates/panelists/_reports.html
@@ -20,7 +20,17 @@
         <a href="{{ url_for('panelists.average_scores_by_year') }}">Average Scores by Year</a>
     </dt>
     <dd>
-        This report breaks down the average scores for each panelist, broken out
+        This report breaks down the average scores for a given panelist, broken out
+        by year. The averages excludes scores from Best Of and Repeat shows; in
+        addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
+        show are also excluded, due to the unique scoring used.
+    </dd>
+
+    <dt>
+        <a href="{{ url_for('panelists.average_scores_by_year_all') }}">Average Scores by Year: All</a>
+    </dt>
+    <dd>
+        This report breaks down the average scores for all panelists, broken out
         by year. The averages excludes scores from Best Of and Repeat shows; in
         addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
         show are also excluded, due to the unique scoring used.

--- a/app/panelists/templates/panelists/_reports.html
+++ b/app/panelists/templates/panelists/_reports.html
@@ -21,7 +21,9 @@
     </dt>
     <dd>
         This report breaks down the average scores for each panelist, broken out
-        by year. The counts excludes scores Best Of and Repeat shows.
+        by year. The averages excludes scores from Best Of and Repeat shows; in
+        addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
+        show are also excluded, due to the unique scoring used.
     </dd>
 
     <dt>

--- a/app/panelists/templates/panelists/_reports.html
+++ b/app/panelists/templates/panelists/_reports.html
@@ -17,6 +17,14 @@
     </dd>
 
     <dt>
+        <a href="{{ url_for('panelists.average_scores_by_year') }}">Average Scores by Year</a>
+    </dt>
+    <dd>
+        This report breaks down the average scores for each panelist, broken out
+        by year. The counts excludes scores Best Of and Repeat shows.
+    </dd>
+
+    <dt>
         <a href="{{ url_for('panelists.bluff_stats') }}">Bluff the Listener Statistics</a>
     </dt>
     <dd>

--- a/app/panelists/templates/panelists/appearances-by-year.html
+++ b/app/panelists/templates/panelists/appearances-by-year.html
@@ -19,6 +19,7 @@
 {% endblock synopsis %}
 
 {% block content %}
+{% if panelists and show_years %}
 <!-- Start Report Section -->
 <div id="appearance-by-year">
 <table class="pure-table pure-table-bordered">
@@ -47,7 +48,7 @@
             </td>
             {% for year in show_years %}
                 {% if year in panelist.appearances %}
-            <td class="centered middle year">{{ panelist.appearances[year] }}</td>
+            <td class="centered middle year" title="{{ panelist.name }}: {{ year }}">{{ panelist.appearances[year] }}</td>
                 {% else %}
             <td class="no-data">-</td>
                 {% endif %}
@@ -68,4 +69,7 @@
 </table>
 </div>
 <!-- End Report Section -->
+{% else %}
+<p>No data available.</p>
+{% endif %}
 {% endblock content %}

--- a/app/panelists/templates/panelists/average-scores-by-year-all.html
+++ b/app/panelists/templates/panelists/average-scores-by-year-all.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block title %}Average Scores by Year: All | Panelists{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('main.index') }}">Home</a></li>
+        <li><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Average Scores by Year: All</h2>
+<p>
+    This report breaks down the average scores for all panelists, broken out
+    by year. The averages excludes scores from Best Of and Repeat shows; in
+    addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
+    show are also excluded, due to the unique scoring used.
+</p>
+{% endblock synopsis %}
+
+{% block content %}
+{% if average_scores and years %}
+<!-- Start Report Section -->
+<div id="average-scores-by-year-all">
+<table class="pure-table pure-table-bordered">
+    <colgroup>
+        <col class="name panelist">
+        {% for col in range((years|length + 1)) %}
+            <col class="stats float">
+        {% endfor %}
+    </colgroup>
+    <thead>
+        <tr>
+            <th scope="col">Panelist</th>
+            {% for year in years %}
+            <th scope="col">{{ year }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for panelist in average_scores %}
+        <tr>
+            <td class="name panelist">
+                <a href="{{ stats_url }}/panelists/{{ panelist.slug }}">
+                    {{ panelist.name }}
+                </a>
+            </td>
+            {% for year in years %}
+                {% if year in panelist.averages and panelist.averages[year] > 0%}
+            <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">{{ panelist.averages[year] }}</td>
+                {% else %}
+            <td class="no-data stats float">-</td>
+                {% endif %}
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col">Panelist</th>
+            {% for year in years %}
+            <th scope="col">{{ year }}</th>
+            {% endfor %}
+        </tr>
+    </tfoot>
+</table>
+</div>
+<!-- End Report Section -->
+{% else %}
+<p>No data available.</p>
+{% endif %}
+{% endblock content %}

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Average Scores by Year | Panelists{% endblock %}
+
+{% block breadcrumb %}
+<div id="breadcrumb">
+    <ul>
+        <li><a href="{{ url_for('main.index') }}">Home</a></li>
+        <li><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+    </ul>
+</div>
+{% endblock breadcrumb %}
+
+{% block synopsis %}
+<h2>Average Scores by Year</h2>
+<p>
+    This report breaks down the average scores for each panelist, broken out
+    by year. The counts excludes scores Best Of and Repeat shows.
+</p>
+{% endblock synopsis %}
+
+{% block content %}
+{% if average_scores and years %}
+<!-- Start Report Section -->
+<div id="average-scores-by-year">
+<table class="pure-table pure-table-bordered">
+    <colgroup>
+        <col class="name panelist">
+        {% for col in range((years|length + 1)) %}
+            <col class="stats float">
+        {% endfor %}
+    </colgroup>
+    <thead>
+        <tr>
+            <th scope="col">Panelist</th>
+            {% for year in years %}
+            <th scope="col">{{ year }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for panelist in average_scores %}
+        <tr>
+            <td class="name panelist">
+                <a href="{{ stats_url }}/panelists/{{ panelist.slug }}">
+                    {{ panelist.name }}
+                </a>
+            </td>
+            {% for year in years %}
+                {% if year in panelist.averages and panelist.averages[year] > 0%}
+            <td class="centered middle stats float">{{ panelist.averages[year] }}</td>
+                {% else %}
+            <td class="no-data stats float">-</td>
+                {% endif %}
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col">Panelist</th>
+            {% for year in years %}
+            <th scope="col">{{ year }}</th>
+            {% endfor %}
+        </tr>
+    </tfoot>
+</table>
+</div>
+<!-- End Report Section -->
+{% else %}
+<p>No data available.</p>
+{% endif %}
+{% endblock content %}

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -13,7 +13,7 @@
 {% block synopsis %}
 <h2>Average Scores by Year</h2>
 <p>
-    This report breaks down the average scores for each panelist, broken out
+    This report breaks down the average scores for a given panelist, broken out
     by year. The averages excludes scores from Best Of and Repeat shows; in
     addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
     show are also excluded, due to the unique scoring used.
@@ -21,54 +21,62 @@
 {% endblock synopsis %}
 
 {% block content %}
-{% if average_scores and years %}
 <!-- Start Report Section -->
-<div id="average-scores-by-year">
+<form method="POST" class="pure-form">
+    <fieldset>
+        <legend>Select a panelist to view average scores by year:</legend>
+        <div class="panelist-fields">
+            <label for="panelist">Panelist:</label>
+            <select id="panelist" name="panelist">
+                <option value="">-- Please choose a panelist --</option>
+                {% for panelist in all_panelists %}
+                {% if request.form.panelist == all_panelists[panelist].slug %}
+                <option value="{{ all_panelists[panelist].slug }}" selected>{{ all_panelists[panelist].name }}</option>
+                {% else %}
+                <option value="{{ all_panelists[panelist].slug }}">{{ all_panelists[panelist].name }}</option>
+                {% endif %}
+                {% endfor %}
+            </select>
+        </div>
+        <div class="panelist-options">
+            <button type="submit" class="pure-button pure-button-primary">Submit</button>
+        </div>
+    </fieldset>
+</form>
+
+{% if request.method == "POST" %}
+<hr>
+{% if not average_scores %}
+<p class="result-message">Incorrect or no panelist selected.</p>
+{% else %}
+<section class="pvp">
+<h3>{{ panelist_info.name }}</h3>
 <table class="pure-table pure-table-bordered">
     <colgroup>
-        <col class="name panelist">
-        {% for col in range((years|length + 1)) %}
-            <col class="stats float">
-        {% endfor %}
+        <col class="date year">
+        <col class="stats float">
     </colgroup>
     <thead>
         <tr>
-            <th scope="col">Panelist</th>
-            {% for year in years %}
-            <th scope="col">{{ year }}</th>
-            {% endfor %}
+            <th scope="col">Year</th>
+            <th scope="col">Average</th>
         </tr>
     </thead>
     <tbody>
-        {% for panelist in average_scores %}
+    {% for year in average_scores.averages %}
         <tr>
-            <td class="name panelist">
-                <a href="{{ stats_url }}/panelists/{{ panelist.slug }}">
-                    {{ panelist.name }}
-                </a>
-            </td>
-            {% for year in years %}
-                {% if year in panelist.averages and panelist.averages[year] > 0%}
-            <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">{{ panelist.averages[year] }}</td>
-                {% else %}
+            <td>{{ year }}</td>
+            {% if average_scores.averages[year] %}
+            <td>{{ average_scores.averages[year] }}</td>
+            {% else %}
             <td class="no-data stats float">-</td>
-                {% endif %}
-            {% endfor %}
+            {% endif %}
         </tr>
-        {% endfor %}
+    {% endfor%}
     </tbody>
-    <tfoot>
-        <tr>
-            <th scope="col">Panelist</th>
-            {% for year in years %}
-            <th scope="col">{{ year }}</th>
-            {% endfor %}
-        </tr>
-    </tfoot>
 </table>
-</div>
-<!-- End Report Section -->
-{% else %}
-<p>No data available.</p>
+</section>
 {% endif %}
+{% endif %}
+<!-- End Report Section -->
 {% endblock content %}

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -14,7 +14,9 @@
 <h2>Average Scores by Year</h2>
 <p>
     This report breaks down the average scores for each panelist, broken out
-    by year. The counts excludes scores Best Of and Repeat shows.
+    by year. The averages excludes scores from Best Of and Repeat shows; in
+    addition to, scores from the <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>
+    show are also excluded, due to the unique scoring used.
 </p>
 {% endblock synopsis %}
 
@@ -47,7 +49,7 @@
             </td>
             {% for year in years %}
                 {% if year in panelist.averages and panelist.averages[year] > 0%}
-            <td class="centered middle stats float">{{ panelist.averages[year] }}</td>
+            <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">{{ panelist.averages[year] }}</td>
                 {% else %}
             <td class="no-data stats float">-</td>
                 {% endif %}

--- a/app/panelists/templates/panelists/panelist-pvp-scoring.html
+++ b/app/panelists/templates/panelists/panelist-pvp-scoring.html
@@ -33,7 +33,7 @@
         <div class="panelist-fields">
             <label for="panelist-1">Panelist 1:</label>
             <select id="panelist-1" name="panelist_1">
-                <option value="">-- Please chose a panelist --</option>
+                <option value="">-- Please choose a panelist --</option>
                 {% for slug, name in panelists.items() %}
                 {% if request.form.panelist_1 == slug %}
                 <option value="{{ slug }}" selected>{{ name }}</option>
@@ -46,7 +46,7 @@
         <div class="panelist-fields">
             <label for="panelist-2">Panelist 2:</label>
             <select id="panelist-2" name="panelist_2">
-                <option value="">-- Please chose a panelist --</option>
+                <option value="">-- Please choose a panelist --</option>
                 {% for slug, name in panelists.items() %}
                 {% if request.form.panelist_2 == slug %}
                 <option value="{{ slug }}" selected>{{ name }}</option>

--- a/app/panelists/templates/panelists/panelist-pvp.html
+++ b/app/panelists/templates/panelists/panelist-pvp.html
@@ -26,7 +26,7 @@
         <div class="panelist-fields">
             <label for="panelist">Panelist:</label>
             <select id="panelist" name="panelist">
-                <option value="">-- Please chose a panelist --</option>
+                <option value="">-- Please choose a panelist --</option>
                 {% for panelist in all_panelists %}
                 {% if request.form.panelist == all_panelists[panelist].slug %}
                 <option value="{{ all_panelists[panelist].slug }}" selected>{{ all_panelists[panelist].name }}</option>

--- a/app/sitemaps/templates/sitemaps/panelists.xml
+++ b/app/sitemaps/templates/sitemaps/panelists.xml
@@ -9,6 +9,10 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("panelists.average_scores_by_year_all") }}</loc>
+    <changefreq>daily</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("panelists.bluff_stats") }}</loc>
     <changefreq>daily</changefreq>
   </url>

--- a/app/sitemaps/templates/sitemaps/panelists.xml
+++ b/app/sitemaps/templates/sitemaps/panelists.xml
@@ -9,6 +9,10 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("panelists.average_scores_by_year") }}</loc>
+    <changefreq>daily</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("panelists.average_scores_by_year_all") }}</loc>
     <changefreq>daily</changefreq>
   </url>

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -198,9 +198,18 @@
         cursor: help;
     }
 
-    #appearance-by-year {
+    #appearance-by-year, #average-scores-by-year {
         max-height: 80vh;
         overflow: scroll;
+    }
+
+    #appearance-by-year td.name.panelist,
+    #average-scores-by-year td.name.panelist {
+        min-width: 7.5rem;
+    }
+
+    #average-scores-by-year td.stats.float {
+        min-width: 5rem;
     }
 
     .pure-form fieldset {
@@ -292,7 +301,7 @@
         text-align: center;
     }
 
-    #appearance-by-year td.no-data {
+    #appearance-by-year td.no-data, #average-scores-by-year td.no-data {
         vertical-align: middle !important;
     }
 
@@ -343,7 +352,7 @@
 }
 
 @media only screen and (max-width: 480px) {
-    #appearance-by-year {
+    #appearance-by-year, #average-scores-by-year {
         font-size: 0.975rem;
         margin: 0;
         max-height: 45vh;
@@ -373,9 +382,9 @@
         visibility: hidden;
     }
 
-    #appearance-by-year {
+    #appearance-by-year, #average-scores-by-year {
         max-height: initial;
-        max-width: initial;
-        overflow: initial;
+        max-width: 100%;
+        overflow: visible;
     }
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -203,13 +203,16 @@
         overflow: scroll;
     }
 
+    #appearance-by-year col.name.panelist,
     #appearance-by-year td.name.panelist,
+    #average-scores-by-year col.name.panelist,
     #average-scores-by-year td.name.panelist {
         min-width: 7.5rem;
     }
 
+    #average-scores-by-year col.stats.float,
     #average-scores-by-year td.stats.float {
-        min-width: 5rem;
+        min-width: 4.5rem;
     }
 
     .pure-form fieldset {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -198,20 +198,20 @@
         cursor: help;
     }
 
-    #appearance-by-year, #average-scores-by-year {
+    #appearance-by-year, #average-scores-by-year-all {
         max-height: 80vh;
         overflow: scroll;
     }
 
     #appearance-by-year col.name.panelist,
     #appearance-by-year td.name.panelist,
-    #average-scores-by-year col.name.panelist,
-    #average-scores-by-year td.name.panelist {
+    #average-scores-by-year-all col.name.panelist,
+    #average-scores-by-year-all td.name.panelist {
         min-width: 7.5rem;
     }
 
-    #average-scores-by-year col.stats.float,
-    #average-scores-by-year td.stats.float {
+    #average-scores-by-year-all col.stats.float,
+    #average-scores-by-year-all td.stats.float {
         min-width: 4.5rem;
     }
 
@@ -304,7 +304,7 @@
         text-align: center;
     }
 
-    #appearance-by-year td.no-data, #average-scores-by-year td.no-data {
+    #appearance-by-year td.no-data, #average-scores-by-year-all td.no-data {
         vertical-align: middle !important;
     }
 
@@ -355,7 +355,7 @@
 }
 
 @media only screen and (max-width: 480px) {
-    #appearance-by-year, #average-scores-by-year {
+    #appearance-by-year, #average-scores-by-year-all {
         font-size: 0.975rem;
         margin: 0;
         max-height: 45vh;
@@ -385,7 +385,7 @@
         visibility: hidden;
     }
 
-    #appearance-by-year, #average-scores-by-year {
+    #appearance-by-year, #average-scores-by-year-all {
         max-height: initial;
         max-width: 100%;
         overflow: visible;

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.2.5"
+APP_VERSION = "2.3.0"

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -32,6 +32,16 @@ def test_appearances_by_year(client: FlaskClient) -> None:
     assert response.status_code == 200
     assert b"Appearances by Year" in response.data
     assert b"Total" in response.data
+    assert b"No data available" not in response.data
+
+
+def test_average_scores_by_year(client: FlaskClient) -> None:
+    """Testing panelists.routes.average_scores_by_year"""
+    response: TestResponse = client.get("/panelists/average-scores-by-year")
+    assert response.status_code == 200
+    assert b"Average Scores by Year" in response.data
+    assert b"stats float" in response.data
+    assert b"No data available" not in response.data
 
 
 def test_bluff_stats(client: FlaskClient) -> None:

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -26,21 +26,41 @@ def test_aggregate_scores(client: FlaskClient) -> None:
     assert b"Aggregate Score Spread" in response.data
 
 
+def test_average_scores_by_year(client) -> None:
+    """Testing panelists.routes.average_scores_by_year (GET)"""
+    response: TestResponse = client.get("/panelists/average-scores-by-year")
+    assert response.status_code == 200
+    assert b"Average Scores by Year" in response.data
+    assert b"Please choose a panelist" in response.data
+
+
+@pytest.mark.parametrize("panelist_slug", ["faith-salie"])
+def test_average_scores_by_year_post(client: FlaskClient, panelist_slug: str) -> None:
+    """Testing panelists.routes.average_scores_by_year (POST)"""
+    response: TestResponse = client.post(
+        "/panelists/average-scores-by-year", data={"panelist": panelist_slug}
+    )
+    assert response.status_code == 200
+    assert b"Average Scores by Year" in response.data
+    assert panelist_slug.encode("utf-8") in response.data
+    assert b"stats float" in response.data
+
+
+def test_average_scores_by_year_all(client: FlaskClient) -> None:
+    """Testing panelists.routes.all_average_scores_by_year_all"""
+    response: TestResponse = client.get("/panelists/average-scores-by-year-all")
+    assert response.status_code == 200
+    assert b"Average Scores by Year: All" in response.data
+    assert b"stats float" in response.data
+    assert b"No data available" not in response.data
+
+
 def test_appearances_by_year(client: FlaskClient) -> None:
     """Testing panelists.routes.appearances_by_year"""
     response: TestResponse = client.get("/panelists/appearances-by-year")
     assert response.status_code == 200
     assert b"Appearances by Year" in response.data
     assert b"Total" in response.data
-    assert b"No data available" not in response.data
-
-
-def test_average_scores_by_year(client: FlaskClient) -> None:
-    """Testing panelists.routes.average_scores_by_year"""
-    response: TestResponse = client.get("/panelists/average-scores-by-year")
-    assert response.status_code == 200
-    assert b"Average Scores by Year" in response.data
-    assert b"stats float" in response.data
     assert b"No data available" not in response.data
 
 
@@ -99,7 +119,7 @@ def test_panelist_pvp(client) -> None:
     response: TestResponse = client.get("/panelists/panelist-pvp")
     assert response.status_code == 200
     assert b"Panelist vs Panelist" in response.data
-    assert b"Please chose a panelist" in response.data
+    assert b"Please choose a panelist" in response.data
 
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
@@ -128,7 +148,7 @@ def test_panelist_pvp_scoring(client: FlaskClient) -> None:
     response: TestResponse = client.get("/panelists/panelist-vs-panelist-scoring")
     assert response.status_code == 200
     assert b"Panelist vs Panelist Scoring" in response.data
-    assert b"Please chose a panelist" in response.data
+    assert b"Please choose a panelist" in response.data
 
 
 @pytest.mark.parametrize("panelist_1, panelist_2", [("adam-felber", "faith-salie")])


### PR DESCRIPTION
### Application Changes

- Addition of Panelist Average Scores by Year and Panelist Average Scores by Year: All reports
- Modify CSS for Panelist Appearances by Year report to correct column sizes
- Add tooltips to each data cell in the Panelist Appearances by Year report to display the panelist name and year
- Fix issue where printing out Panelist Appearances by Year report from cropping out the table when page scaling is reduced
- Fixed typos in dropdown menus when choosing panelists

### Development Changes

- Added tests for Panelist Average Scores by Year and Panelist Average Scores by Year: All reports
- Updated tests for Panelist Appearances by Year and Panelist vs Panelist reports