### PR TITLE
Add filter to exclude any possible NULL panelistscore values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.1
+
+### Application Changes
+
+- Add filter to Panelist Average Scores by Year database query to exclude any `NULL` values for panelist scores to prevent skewing of results
+
 ## 2.3.0
 
 ### Application Changes

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -69,6 +69,7 @@ def retrieve_panelist_yearly_average(
     JOIN ww_shows s ON s.showid = pm.showid
     WHERE p.panelistslug = %s
     AND s.bestof = 0 AND s.repeatshowid IS NULL
+    AND pm.panelistscore IS NOT NULL
     AND s.showdate <> '2018-10-27'
     GROUP BY YEAR(s.showdate)
     ORDER BY YEAR(s.showdate) ASC

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.3.0"
+APP_VERSION = "2.3.1"


### PR DESCRIPTION
## Application Changes

- Add filter to Panelist Average Scores by Year database query to exclude any `NULL` values for panelist scores to prevent skewing of results