### PR TITLE
Add Support for Panelist Decimal Scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Application Changes
 
-- Add support for generating reports using panelist decimal scores
+- Add support for the new decimal panelist score column, `panelistscore_decimal` in the `ww_showpnlmap` table of the Wait Wait Stats Database.
+- Add a `use_decimal_scores` setting in `config.json` to enable or disable pulling data from the new column. The default is `false`
+- All calculations that use of decimal scores, versus integer scores, use the Python Decimal data type
+- Change the rounding of certain stats from 4 decimal places to 5 decimal places
 
 ### Component Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.4.0
+
+### Application Changes
+
+- Add support for generating reports using panelist decimal scores
+
+### Component Changes
+
+- Upgrade NumPy from 1.24.2 to 1.24.3
+
+### Development Changes
+
+- Upgrade black from 23.3.0 to 23.7.0
+
 ## 2.3.1
 
 ### Application Changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,9 +60,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-dev@wwdt.me. All complaints will be reviewed and investigated promptly and
-fairly.
+reported to the community leaders responsible for enforcement at [dev@wwdt.me](mailto:dev@wwdt.me).
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,14 +67,16 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
-    app.jinja_env.globals["use_decimal_scores"] = _config["settings"]
+    app.jinja_env.globals["use_decimal_scores"] = _config["settings"]["use_decimal_scores"]
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify
     app.jinja_env.filters["markdown"] = utility.md_to_html
 
     # Check to see if panelistscore_decimal column exists and set a flag
-    app.config["app_settings"]["has_decimal_scores_column"] = utility.panelist_decimal_score_exists()
+    app.config["app_settings"][
+        "has_decimal_scores_column"
+    ] = utility.panelist_decimal_score_exists(database_settings=app.config["database"])
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Core Application for Wait Wait Reports"""
 from flask import Flask
@@ -67,10 +67,14 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["use_decimal_scores"] = _config["settings"]
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify
     app.jinja_env.filters["markdown"] = utility.md_to_html
+
+    # Check to see if panelistscore_decimal column exists and set a flag
+    app.config["app_settings"]["has_decimal_scores_column"] = utility.panelist_decimal_score_exists()
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Configuration Loading and Parsing for Wait Wait Reports"""
 
@@ -57,6 +57,9 @@ def load_config(
     settings_config["app_time_zone"] = time_zone_object
     settings_config["time_zone"] = time_zone_string
     database_config["time_zone"] = time_zone_string
+
+    # Read in setting on whether to use decimal scores
+    settings_config["use_decimal_scores"] = bool(settings_config.get("use_decimal_scores", False))
 
     return {
         "database": database_config,

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # Shared Dictionaries for Wait Wait Reports
 

--- a/app/locations/reports/average_scores.py
+++ b/app/locations/reports/average_scores.py
@@ -7,38 +7,61 @@
 from decimal import Decimal
 from typing import Any, Dict, List
 
+from flask import current_app
 import mysql.connector
 
 
 def retrieve_average_scores_by_location(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict[str, Any]]:
     """Retrieve average scores sorted by location using a pre-written
     database query"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
-    cursor = database_connection.cursor(named_tuple=True)
-
     # Excluding 25th Anniversary Show at Chicago Theatre from calculations
     # due to non-standard number of panelist scores and score totals
-    query = (
-        "SELECT l.locationid, l.venue, l.city, l.state, "
-        "AVG(pm.panelistscore) AS average_score, "
-        "SUM(pm.panelistscore) / (COUNT(s.showid) / 3) AS average_total, "
-        "COUNT(s.showid) / 3 AS show_count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "join ww_showlocationmap lm ON lm.showid = pm.showid "
-        "JOIN ww_locations l ON l.locationid = lm.locationid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND l.locationid <> 3 "  # Ignore any TBD locations
-        "AND s.showdate <> '2018-10-27' "
-        "GROUP BY l.locationid "
-        "ORDER BY average_score DESC, average_total DESC, "
-        "show_count DESC, l.venue ASC;"
-    )
+    if use_decimal_scores:
+        query = """
+            SELECT l.locationid, l.venue, l.city, l.state,
+            AVG(pm.panelistscore_decimal) AS average_score,
+            SUM(pm.panelistscore_decimal) / (COUNT(s.showid) / 3) AS average_total,
+            COUNT(s.showid) / 3 AS show_count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_showlocationmap lm ON lm.showid = pm.showid
+            JOIN ww_locations l ON l.locationid = lm.locationid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND l.locationid <> 3 -- Ignore any TBD locations
+            AND s.showdate <> '2018-10-27'
+            GROUP BY l.locationid
+            ORDER BY average_score DESC, average_total DESC,
+            show_count DESC, l.venue ASC;
+            """
+    else:
+        query = """
+            SELECT l.locationid, l.venue, l.city, l.state,
+            AVG(pm.panelistscore) AS average_score,
+            SUM(pm.panelistscore) / (COUNT(s.showid) / 3) AS average_total,
+            COUNT(s.showid) / 3 AS show_count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_showlocationmap lm ON lm.showid = pm.showid
+            JOIN ww_locations l ON l.locationid = lm.locationid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND l.locationid <> 3 -- Ignore any TBD locations
+            AND s.showdate <> '2018-10-27'
+            GROUP BY l.locationid
+            ORDER BY average_score DESC, average_total DESC,
+            show_count DESC, l.venue ASC;
+            """
+    cursor = database_connection.cursor(named_tuple=True)
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -48,16 +71,29 @@ def retrieve_average_scores_by_location(
 
     _average_scores = []
     for row in result:
-        _average_scores.append(
-            {
-                "id": row.locationid,
-                "venue": row.venue,
-                "city": row.city,
-                "state": row.state,
-                "average_score": Decimal(row.average_score).normalize(),
-                "average_total": Decimal(row.average_total).normalize(),
-                "show_count": Decimal(row.show_count).normalize(),
-            }
-        )
+        if use_decimal_scores:
+            _average_scores.append(
+                {
+                    "id": row.locationid,
+                    "venue": row.venue,
+                    "city": row.city,
+                    "state": row.state,
+                    "average_score": round(Decimal(row.average_score), 5),
+                    "average_total": round(Decimal(row.average_total), 5),
+                    "show_count": int(row.show_count),
+                }
+            )
+        else:
+            _average_scores.append(
+                {
+                    "id": row.locationid,
+                    "venue": row.venue,
+                    "city": row.city,
+                    "state": row.state,
+                    "average_score": round(row.average_score, 5),
+                    "average_total": round(row.average_total, 5),
+                    "show_count": int(row.show_count),
+                }
+            )
 
     return _average_scores

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -24,7 +24,8 @@ def average_scores():
     """View: Locations Average Scores Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _locations = retrieve_average_scores_by_location(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
     return render_template("locations/average-scores.html", locations=_locations)

--- a/app/locations/templates/locations/average-scores.html
+++ b/app/locations/templates/locations/average-scores.html
@@ -30,8 +30,8 @@
         <col class="name venue">
         <col class="name city">
         <col class="name state">
-        <col class="score">
-        <col class="score">
+        <col class="stats float">
+        <col class="stats float">
         <col class="dates">
     </colgroup>
     <thead>
@@ -62,12 +62,15 @@
             {% else %}
             <td class="no-data">-</td>
             {% endif %}
-            {# Using str.format() in order to get clean, floating output
-                from Decimal numbers
-            #}
-            <td>{{ "{:f}".format(location.average_score) }}</td>
-            <td>{{ "{:f}".format(location.average_total) }}</td>
-            <td>{{ "{:f}".format(location.show_count) }}</td>
+            {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(location.average_score.normalize()) }}</td>
+            <td>{{ "{:f}".format(location.average_total.normalize()) }}</td>
+            <td>{{ location.show_count }}</td>
+            {% else %}
+            <td>{{ location.average_score }}</td>
+            <td>{{ location.average_total }}</td>
+            <td>{{ location.show_count }}</td>
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>

--- a/app/panelists/__init__.py
+++ b/app/panelists/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists module for Wait Wait Reports"""

--- a/app/panelists/redirects.py
+++ b/app/panelists/redirects.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists Redirect Routes for Wait Wait Reports"""
 from flask import Blueprint, url_for

--- a/app/panelists/reports/__init__.py
+++ b/app/panelists/reports/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists Reports module for Wait Wait Reports"""

--- a/app/panelists/reports/aggregate_scores.py
+++ b/app/panelists/reports/aggregate_scores.py
@@ -1,30 +1,48 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Aggregate Scores Report Functions"""
-from typing import Any, Dict, List
+from decimal import Decimal
+from typing import Any, Dict, List, Union
+from flask import current_app
 
 import mysql.connector
 import numpy
 
 
-def retrieve_all_scores(database_connection: mysql.connector.connect) -> List[int]:
+def retrieve_all_scores(
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+) -> List[Union[int, Decimal]]:
     """Retrieve a list of all panelist scores from non-Best Of and
     non-Repeat shows"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT pm.panelistscore_decimal FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            ORDER BY pm.panelistscore_decimal ASC;
+            """
+    else:
+        query = """
+            SELECT pm.panelistscore FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore IS NOT NULL
+            ORDER BY pm.panelistscore ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT pm.panelistscore FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND pm.panelistscore IS NOT NULL "
-        "ORDER BY pm.panelistscore ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -36,24 +54,40 @@ def retrieve_all_scores(database_connection: mysql.connector.connect) -> List[in
 
 
 def retrieve_score_spread(
-    database_connection: mysql.connector.connect,
-) -> List[Dict[str, int]]:
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+) -> List[Dict[str, Union[int, Decimal]]]:
     """Retrieve a list of grouped panelist scores from non-Best Of and
     non-Repeat shows"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT pm.panelistscore_decimal, COUNT(pm.panelistscore_decimal) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore_decimal IS NOT NULL
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY pm.panelistscore_decimal
+            ORDER BY pm.panelistscore_decimal ASC;
+            """
+    else:
+        query = """
+            SELECT pm.panelistscore, COUNT(pm.panelistscore) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore IS NOT NULL
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY pm.panelistscore
+            ORDER BY pm.panelistscore ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT pm.panelistscore, COUNT(pm.panelistscore) AS count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistscore IS NOT NULL "
-        "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY pm.panelistscore "
-        "ORDER BY pm.panelistscore ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -73,15 +107,26 @@ def retrieve_score_spread(
     return scores
 
 
-def calculate_stats(scores: List[int]) -> Dict[str, Any]:
+def calculate_stats(scores: List[int], decimal_scores: bool = False) -> Dict[str, Any]:
     """Calculate stats for all of the panelist scores"""
 
-    return {
-        "count": len(scores),
-        "minimum": int(numpy.amin(scores)),
-        "maximum": int(numpy.amax(scores)),
-        "mean": round(numpy.mean(scores), 4),
-        "median": int(numpy.median(scores)),
-        "standard_deviation": round(numpy.std(scores), 4),
-        "sum": int(numpy.sum(scores)),
-    }
+    if decimal_scores:
+        return {
+            "count": len(scores),
+            "minimum": Decimal(numpy.amin(scores)),
+            "maximum": Decimal(numpy.amax(scores)),
+            "mean": Decimal(numpy.mean(scores)),
+            "median": Decimal(numpy.median(scores)),
+            "standard_deviation": Decimal(numpy.std(scores)),
+            "sum": Decimal(numpy.sum(scores)),
+        }
+    else:
+        return {
+            "count": len(scores),
+            "minimum": int(numpy.amin(scores)),
+            "maximum": int(numpy.amax(scores)),
+            "mean": round(numpy.mean(scores), 4),
+            "median": int(numpy.median(scores)),
+            "standard_deviation": round(numpy.std(scores), 4),
+            "sum": int(numpy.sum(scores)),
+        }

--- a/app/panelists/reports/aggregate_scores.py
+++ b/app/panelists/reports/aggregate_scores.py
@@ -28,7 +28,7 @@ def retrieve_all_scores(
 
     if use_decimal_scores:
         query = """
-            SELECT pm.panelistscore_decimal FROM ww_showpnlmap pm
+            SELECT pm.panelistscore_decimal AS score FROM ww_showpnlmap pm
             JOIN ww_shows s ON s.showid = pm.showid
             WHERE s.bestof = 0 AND s.repeatshowid IS NULL
             AND pm.panelistscore_decimal IS NOT NULL
@@ -36,7 +36,7 @@ def retrieve_all_scores(
             """
     else:
         query = """
-            SELECT pm.panelistscore FROM ww_showpnlmap pm
+            SELECT pm.panelistscore AS score FROM ww_showpnlmap pm
             JOIN ww_shows s ON s.showid = pm.showid
             WHERE s.bestof = 0 AND s.repeatshowid IS NULL
             AND pm.panelistscore IS NOT NULL
@@ -50,7 +50,7 @@ def retrieve_all_scores(
     if not result:
         return None
 
-    return [row.panelistscore for row in result]
+    return [row.score for row in result]
 
 
 def retrieve_score_spread(
@@ -69,7 +69,8 @@ def retrieve_score_spread(
 
     if use_decimal_scores:
         query = """
-            SELECT pm.panelistscore_decimal, COUNT(pm.panelistscore_decimal) AS count
+            SELECT pm.panelistscore_decimal AS score,
+            COUNT(pm.panelistscore_decimal) AS count
             FROM ww_showpnlmap pm
             JOIN ww_shows s ON s.showid = pm.showid
             WHERE pm.panelistscore_decimal IS NOT NULL
@@ -79,7 +80,8 @@ def retrieve_score_spread(
             """
     else:
         query = """
-            SELECT pm.panelistscore, COUNT(pm.panelistscore) AS count
+            SELECT pm.panelistscore AS score,
+            COUNT(pm.panelistscore) AS count
             FROM ww_showpnlmap pm
             JOIN ww_shows s ON s.showid = pm.showid
             WHERE pm.panelistscore IS NOT NULL
@@ -99,7 +101,7 @@ def retrieve_score_spread(
     for row in result:
         scores.append(
             {
-                "score": row.panelistscore,
+                "score": row.score,
                 "count": row.count,
             }
         )
@@ -115,9 +117,9 @@ def calculate_stats(scores: List[int], decimal_scores: bool = False) -> Dict[str
             "count": len(scores),
             "minimum": Decimal(numpy.amin(scores)),
             "maximum": Decimal(numpy.amax(scores)),
-            "mean": Decimal(numpy.mean(scores)),
+            "mean": round(Decimal(numpy.mean(scores)), 5),
             "median": Decimal(numpy.median(scores)),
-            "standard_deviation": Decimal(numpy.std(scores)),
+            "standard_deviation": round(Decimal(numpy.std(scores)), 5),
             "sum": Decimal(numpy.sum(scores)),
         }
     else:
@@ -125,8 +127,8 @@ def calculate_stats(scores: List[int], decimal_scores: bool = False) -> Dict[str
             "count": len(scores),
             "minimum": int(numpy.amin(scores)),
             "maximum": int(numpy.amax(scores)),
-            "mean": round(numpy.mean(scores), 4),
+            "mean": round(numpy.mean(scores), 5),
             "median": int(numpy.median(scores)),
-            "standard_deviation": round(numpy.std(scores), 4),
+            "standard_deviation": round(numpy.std(scores), 5),
             "sum": int(numpy.sum(scores)),
         }

--- a/app/panelists/reports/appearances.py
+++ b/app/panelists/reports/appearances.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Appearances Report Functions"""
 from typing import Any, Dict, List
@@ -37,19 +37,19 @@ def retrieve_first_most_recent_appearances(
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT p.panelist, p.panelistslug,
+        MIN(s.showdate) AS min, MAX(s.showdate) AS max
+        FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        WHERE s.bestof = 0
+        AND s.repeatshowid IS null
+        AND p.panelist <> '<Multiple>'
+        GROUP BY p.panelistid
+        ORDER BY p.panelist ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, p.panelistslug, "
-        "MIN(s.showdate) AS min, MAX(s.showdate) AS max "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE s.bestof = 0 "
-        "AND s.repeatshowid IS null "
-        "AND p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelistid "
-        "ORDER BY p.panelist ASC"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -61,17 +61,17 @@ def retrieve_first_most_recent_appearances(
         panelist_appearances[row.panelistslug]["first"] = row.min.isoformat()
         panelist_appearances[row.panelistslug]["most_recent"] = row.max.isoformat()
 
+    query = """
+        SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count
+        FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+        AND p.panelist <> '<Multiple>'
+        GROUP BY p.panelistid
+        ORDER BY p.panelist ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelistid "
-        "ORDER BY p.panelist ASC"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -82,16 +82,16 @@ def retrieve_first_most_recent_appearances(
     for row in result:
         panelist_appearances[row.panelistslug]["count"] = row.count
 
+    query = """
+        SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count
+        FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        WHERE p.panelist <> '<Multiple>'
+        GROUP BY p.panelistid
+        ORDER BY p.panelist ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, p.panelistslug, COUNT(pm.panelistid) AS count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelistid "
-        "ORDER BY p.panelist ASC"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -102,17 +102,17 @@ def retrieve_first_most_recent_appearances(
     for row in result:
         panelist_appearances[row.panelistslug]["count_all"] = row.count
 
+    query = """
+        SELECT p.panelist, p.panelistslug,
+        MIN(s.showdate) AS min, MAX(s.showdate) AS max
+        FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        WHERE p.panelist <> '<Multiple>'
+        GROUP BY p.panelistid
+        ORDER BY p.panelist ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, p.panelistslug, "
-        "MIN(s.showdate) AS min, MAX(s.showdate) AS max "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE p.panelist <> '<Multiple>' "
-        "GROUP BY p.panelistid "
-        "ORDER BY p.panelist ASC"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -111,9 +111,9 @@ def retrieve_panelist_yearly_average(
     for row in result:
         if row.total and row.count:
             if use_decimal_scores:
-                averages[row.year] = Decimal(Decimal(row.total) / Decimal(row.count))
+                averages[row.year] = round(Decimal(row.total) / Decimal(row.count), 5)
             else:
-                averages[row.year] = round(int(row.total) / int(row.count), 4)
+                averages[row.year] = round(int(row.total) / int(row.count), 5)
 
     panelist["averages"] = averages
     return panelist

--- a/app/panelists/reports/common.py
+++ b/app/panelists/reports/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Common Panelist Report Functions"""
 from typing import Any, Dict, List
@@ -13,17 +13,16 @@ def retrieve_panelists(
     database_connection: mysql.connector.connect,
 ) -> List[Dict[str, Any]]:
     """Retrieves a list of all available panelists from the database"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT p.panelistid, p.panelist, p.panelistslug
+        FROM ww_panelists p
+        WHERE p.panelist <> '<Multiple>'
+        ORDER BY p.panelistslug ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelistid, p.panelist, p.panelistslug "
-        "FROM ww_panelists p "
-        "WHERE p.panelist <> '<Multiple>' "
-        "ORDER BY p.panelistslug ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()

--- a/app/panelists/reports/gender_stats.py
+++ b/app/panelists/reports/gender_stats.py
@@ -117,9 +117,9 @@ def retrieve_stats_by_year_gender(
                     all_stats[year][gender] = {
                         "minimum": Decimal(numpy.amin(scores)),
                         "maximum": Decimal(numpy.amax(scores)),
-                        "mean": Decimal(numpy.mean(scores)),
+                        "mean": round(Decimal(numpy.mean(scores)), 5),
                         "median": Decimal(numpy.median(scores)),
-                        "standard_deviation": Decimal(numpy.std(scores)),
+                        "standard_deviation": round(Decimal(numpy.std(scores)), 5),
                         "count": Decimal(len(scores)),
                         "total": Decimal(numpy.sum(scores)),
                     }
@@ -127,9 +127,9 @@ def retrieve_stats_by_year_gender(
                     all_stats[year][gender] = {
                         "minimum": int(numpy.amin(scores)),
                         "maximum": int(numpy.amax(scores)),
-                        "mean": round(numpy.mean(scores), 4),
+                        "mean": round(numpy.mean(scores), 5),
                         "median": int(numpy.median(scores)),
-                        "standard_deviation": round(numpy.std(scores), 4),
+                        "standard_deviation": round(numpy.std(scores), 5),
                         "count": len(scores),
                         "total": int(numpy.sum(scores)),
                     }

--- a/app/panelists/reports/gender_stats.py
+++ b/app/panelists/reports/gender_stats.py
@@ -1,27 +1,28 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panel Gender Mix Report Functions"""
-from typing import Any, Dict, List
+from decimal import Decimal
+from typing import Any, Dict, List, Union
 
+from flask import current_app
 import mysql.connector
 import numpy
 
 
 def retrieve_show_years(database_connection: mysql.connector.connect) -> List[int]:
     """Retrieve a list of available show years"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+    SELECT DISTINCT YEAR(showdate)
+    FROM ww_shows
+    ORDER BY YEAR(showdate) ASC;
+    """
     cursor = database_connection.cursor()
-    query = (
-        "SELECT DISTINCT YEAR(showdate) "
-        "FROM ww_shows "
-        "ORDER BY YEAR(showdate) ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -33,10 +34,18 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> List[in
 
 
 def retrieve_scores_by_year_gender(
-    year: int, gender: str, database_connection: mysql.connector.connect
-) -> List[int]:
+    year: int,
+    gender: str,
+    database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
+) -> List[Union[int, Decimal]]:
     """Retrieve a list of panelist scores for a given year and
     panelists of the requested gender"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not gender:
         return None
@@ -46,17 +55,29 @@ def retrieve_scores_by_year_gender(
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT pm.panelistscore_decimal AS score FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore IS NOT NULL
+            AND p.panelistgender = %s
+            AND YEAR(s.showdate) = %s
+            ORDER BY s.showdate ASC;
+            """
+    else:
+        query = """
+            SELECT pm.panelistscore AS score FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore IS NOT NULL
+            AND p.panelistgender = %s
+            AND YEAR(s.showdate) = %s
+            ORDER BY s.showdate ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT pm.panelistscore FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND pm.panelistscore IS NOT NULL "
-        "AND p.panelistgender = %s "
-        "AND YEAR(s.showdate) = %s "
-        "ORDER BY s.showdate ASC;"
-    )
     cursor.execute(query, (panelist_gender, year))
     result = cursor.fetchall()
     cursor.close()
@@ -64,14 +85,20 @@ def retrieve_scores_by_year_gender(
     if not result:
         return None
 
-    return [row.panelistscore for row in result]
+    return [row.score for row in result]
 
 
 def retrieve_stats_by_year_gender(
     database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> Dict[str, Any]:
     """Retrieve statistics about panelist scores broken out by year
     and gender"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     show_years = retrieve_show_years(database_connection)
 
@@ -80,18 +107,32 @@ def retrieve_stats_by_year_gender(
         all_stats[year] = {}
         for gender in ["F", "M"]:
             scores = retrieve_scores_by_year_gender(
-                year=year, gender=gender, database_connection=database_connection
+                year=year,
+                gender=gender,
+                database_connection=database_connection,
+                use_decimal_scores=use_decimal_scores,
             )
             if scores:
-                all_stats[year][gender] = {
-                    "minimum": int(numpy.amin(scores)),
-                    "maximum": int(numpy.amax(scores)),
-                    "mean": round(numpy.mean(scores), 4),
-                    "median": int(numpy.median(scores)),
-                    "standard_deviation": round(numpy.std(scores), 4),
-                    "count": len(scores),
-                    "total": int(numpy.sum(scores)),
-                }
+                if use_decimal_scores:
+                    all_stats[year][gender] = {
+                        "minimum": Decimal(numpy.amin(scores)),
+                        "maximum": Decimal(numpy.amax(scores)),
+                        "mean": Decimal(numpy.mean(scores)),
+                        "median": Decimal(numpy.median(scores)),
+                        "standard_deviation": Decimal(numpy.std(scores)),
+                        "count": Decimal(len(scores)),
+                        "total": Decimal(numpy.sum(scores)),
+                    }
+                else:
+                    all_stats[year][gender] = {
+                        "minimum": int(numpy.amin(scores)),
+                        "maximum": int(numpy.amax(scores)),
+                        "mean": round(numpy.mean(scores), 4),
+                        "median": int(numpy.median(scores)),
+                        "standard_deviation": round(numpy.std(scores), 4),
+                        "count": len(scores),
+                        "total": int(numpy.sum(scores)),
+                    }
             else:
                 all_stats[year][gender] = None
 

--- a/app/panelists/reports/panelist_vs_panelist_scoring.py
+++ b/app/panelists/reports/panelist_vs_panelist_scoring.py
@@ -96,7 +96,8 @@ def retrieve_panelists_scores(
         if use_decimal_scores:
             query = """
                 SELECT s.showdate, p.panelist, p.panelistslug,
-                pm.panelistscore_decimal, pm.showpnlrank FROM ww_showpnlmap pm
+                pm.panelistscore_decimal AS score, pm.showpnlrank
+                FROM ww_showpnlmap pm
                 JOIN ww_shows s ON s.showid = pm.showid
                 JOIN ww_panelists p ON p.panelistid = pm.panelistid
                 WHERE s.showid = %s
@@ -105,7 +106,8 @@ def retrieve_panelists_scores(
         else:
             query = """
                 SELECT s.showdate, p.panelist, p.panelistslug,
-                pm.panelistscore, pm.showpnlrank FROM ww_showpnlmap pm
+                pm.panelistscore AS score, pm.showpnlrank
+                FROM ww_showpnlmap pm
                 JOIN ww_shows s ON s.showid = pm.showid
                 JOIN ww_panelists p ON p.panelistid = pm.panelistid
                 WHERE s.showid = %s
@@ -130,21 +132,13 @@ def retrieve_panelists_scores(
             if show_date not in show_scores:
                 show_scores[show_date] = {}
 
-            if use_decimal_scores:
-                panelist_info = {
-                    "slug": row.panelistslug,
-                    "name": row.panelist,
-                    "score": row.panelistscore,
-                    "score_decimal": row.panelistscore_decimal,
-                    "rank": row.showpnlrank,
-                }
-            else:
-                panelist_info = {
-                    "slug": row.panelistslug,
-                    "name": row.panelist,
-                    "score": row.panelistscore,
-                    "rank": row.showpnlrank,
-                }
+            panelist_info = {
+                "slug": row.panelistslug,
+                "name": row.panelist,
+                "score": row.score,
+                "rank": row.showpnlrank,
+            }
+
             show_scores[show_date][row.panelistslug] = panelist_info
 
     return show_scores

--- a/app/panelists/reports/panelist_vs_panelist_scoring.py
+++ b/app/panelists/reports/panelist_vs_panelist_scoring.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist vs Panelist Scoring Report Functions"""
 from typing import Any, Dict, List
 
+from flask import current_app
 import mysql.connector
 
 
@@ -13,27 +14,47 @@ def retrieve_common_shows(
     panelist_slug_1: str,
     panelist_slug_2: str,
     database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> List[int]:
     """Retrieve shows in which the two panelists have appeared
     together on a panel, excluding Best Of, Repeats and the 20th
     Anniversary special"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT pm.showid FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE p.panelistslug IN (%s, %s)
+            AND s.showdate <> '2018-10-27'
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            GROUP BY pm.showid
+            HAVING COUNT(pm.showid) = 2
+            ORDER BY s.showdate ASC;
+            """
+    else:
+        query = """
+            SELECT pm.showid FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE p.panelistslug IN (%s, %s)
+            AND s.showdate <> '2018-10-27'
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore IS NOT NULL
+            GROUP BY pm.showid
+            HAVING COUNT(pm.showid) = 2
+            ORDER BY s.showdate ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT pm.showid FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE p.panelistslug IN (%s, %s) "
-        "AND s.showdate <> '2018-10-27' "
-        "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND pm.panelistscore IS NOT NULL "
-        "GROUP BY pm.showid "
-        "HAVING COUNT(pm.showid) = 2 "
-        "ORDER BY s.showdate ASC;"
-    )
     cursor.execute(
         query,
         (
@@ -55,8 +76,14 @@ def retrieve_panelists_scores(
     panelist_slug_a: str,
     panelist_slug_b: str,
     database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> Dict[str, Any]:
     """Retrieves panelists scores for the two requested panelists"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not show_ids:
         return None
@@ -66,16 +93,25 @@ def retrieve_panelists_scores(
 
     show_scores = {}
     for show_id in show_ids:
+        if use_decimal_scores:
+            query = """
+                SELECT s.showdate, p.panelist, p.panelistslug,
+                pm.panelistscore_decimal, pm.showpnlrank FROM ww_showpnlmap pm
+                JOIN ww_shows s ON s.showid = pm.showid
+                JOIN ww_panelists p ON p.panelistid = pm.panelistid
+                WHERE s.showid = %s
+                AND p.panelistslug IN (%s, %s);
+                """
+        else:
+            query = """
+                SELECT s.showdate, p.panelist, p.panelistslug,
+                pm.panelistscore, pm.showpnlrank FROM ww_showpnlmap pm
+                JOIN ww_shows s ON s.showid = pm.showid
+                JOIN ww_panelists p ON p.panelistid = pm.panelistid
+                WHERE s.showid = %s
+                AND p.panelistslug IN (%s, %s);
+                """
         cursor = database_connection.cursor(named_tuple=True)
-
-        query = (
-            "SELECT s.showdate, p.panelist, p.panelistslug, "
-            "pm.panelistscore, pm.showpnlrank FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-            "WHERE s.showid = %s "
-            "AND p.panelistslug IN (%s, %s);"
-        )
         cursor.execute(
             query,
             (
@@ -94,12 +130,21 @@ def retrieve_panelists_scores(
             if show_date not in show_scores:
                 show_scores[show_date] = {}
 
-            panelist_info = {
-                "slug": row.panelistslug,
-                "name": row.panelist,
-                "score": row.panelistscore,
-                "rank": row.showpnlrank,
-            }
+            if use_decimal_scores:
+                panelist_info = {
+                    "slug": row.panelistslug,
+                    "name": row.panelist,
+                    "score": row.panelistscore,
+                    "score_decimal": row.panelistscore_decimal,
+                    "rank": row.showpnlrank,
+                }
+            else:
+                panelist_info = {
+                    "slug": row.panelistslug,
+                    "name": row.panelist,
+                    "score": row.panelistscore,
+                    "rank": row.showpnlrank,
+                }
             show_scores[show_date][row.panelistslug] = panelist_info
 
     return show_scores

--- a/app/panelists/reports/perfect_scores.py
+++ b/app/panelists/reports/perfect_scores.py
@@ -1,36 +1,55 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Perfect Scores Report Functions"""
 from typing import Dict, Union
 
+from flask import current_app
 import mysql.connector
 
 
 def retrieve_perfect_score_counts(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> Dict[str, Union[str, int]]:
     """Returns a dictionary containing counts of how many times
     panelists have scored a "perfect" score (20 points or higher).
     Excludes Best Of and repeat shows."""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug,
+            COUNT(p.panelist) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore_decimal >= 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist
+            ORDER BY COUNT(p.panelist) DESC;
+            """
+    else:
+        query = """
+            SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug,
+            COUNT(p.panelist) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore >= 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist
+            ORDER BY COUNT(p.panelist) DESC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
-        "COUNT(p.panelist) AS count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistscore >= 20 "
-        "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY p.panelist "
-        "ORDER BY COUNT(p.panelist) DESC;"
-    )
     cursor.execute(query)
     results = cursor.fetchall()
 
@@ -45,16 +64,28 @@ def retrieve_perfect_score_counts(
             "more_perfect": row.count,
         }
 
-    query = (
-        "SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug, "
-        "COUNT(p.panelist) AS count "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistscore = 20 "
-        "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY p.panelist;"
-    )
+    if use_decimal_scores:
+        query = """
+            SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug,
+            COUNT(p.panelist) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore_decimal = 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist;
+            """
+    else:
+        query = """
+            SELECT p.panelist, ANY_VALUE(p.panelistslug) AS panelistslug,
+            COUNT(p.panelist) AS count
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistscore = 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist;
+            """
     cursor.execute(query)
     results = cursor.fetchall()
 

--- a/app/panelists/reports/rankings_summary.py
+++ b/app/panelists/reports/rankings_summary.py
@@ -74,19 +74,19 @@ def retrieve_rankings_by_panelist(
 
     if rankings["count"]:
         rankings["percent_first"] = round(
-            100 * (rankings["first"] / rankings["count"]), 4
+            100 * (rankings["first"] / rankings["count"]), 5
         )
         rankings["percent_first_tied"] = round(
-            100 * (rankings["first_tied"] / rankings["count"]), 4
+            100 * (rankings["first_tied"] / rankings["count"]), 5
         )
         rankings["percent_second"] = round(
-            100 * (rankings["second"] / rankings["count"]), 4
+            100 * (rankings["second"] / rankings["count"]), 5
         )
         rankings["percent_second_tied"] = round(
-            100 * (rankings["second_tied"] / rankings["count"]), 4
+            100 * (rankings["second_tied"] / rankings["count"]), 5
         )
         rankings["percent_third"] = round(
-            100 * (rankings["third"] / rankings["count"]), 4
+            100 * (rankings["third"] / rankings["count"]), 5
         )
 
     return rankings

--- a/app/panelists/reports/rankings_summary.py
+++ b/app/panelists/reports/rankings_summary.py
@@ -19,7 +19,7 @@ def retrieve_rankings_by_panelist(
         database_connection.reconnect()
 
     query = """
-        SELECT ( "
+        SELECT (
         SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
         JOIN ww_shows s ON s.showid = pm.showid
         WHERE pm.panelistid = %s AND pm.showpnlrank = '1' AND

--- a/app/panelists/reports/rankings_summary.py
+++ b/app/panelists/reports/rankings_summary.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Rankings Summary Report Functions"""
 from typing import Any, Dict
@@ -15,35 +15,34 @@ def retrieve_rankings_by_panelist(
     panelist_id: int, database_connection: mysql.connector.connect
 ) -> Dict[str, Any]:
     """Retrieves ranking statistics for the requested panelist"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT ( "
+        SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE pm.panelistid = %s AND pm.showpnlrank = '1' AND
+        s.bestof = 0 and s.repeatshowid IS NULL) AS first, (
+        SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE pm.panelistid = %s AND pm.showpnlrank = '1t' AND
+        s.bestof = 0 and s.repeatshowid IS NULL) AS first_tied, (
+        SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE pm.panelistid = %s AND pm.showpnlrank = '2' AND
+        s.bestof = 0 and s.repeatshowid IS NULL) AS second, (
+        SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE pm.panelistid = %s AND pm.showpnlrank = '2t' AND
+        s.bestof = 0 and s.repeatshowid IS NULL) AS second_tied, (
+        SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm
+        JOIN ww_shows s ON s.showid = pm.showid
+        WHERE pm.panelistid = %s AND pm.showpnlrank = '3' AND
+        s.bestof = 0 and s.repeatshowid IS NULL
+        ) AS third;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT ( "
-        "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistid = %s AND pm.showpnlrank = '1' AND "
-        "s.bestof = 0 and s.repeatshowid IS NULL) AS first, ( "
-        "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistid = %s AND pm.showpnlrank = '1t' AND "
-        "s.bestof = 0 and s.repeatshowid IS NULL) AS first_tied, ( "
-        "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistid = %s AND pm.showpnlrank = '2' AND "
-        "s.bestof = 0 and s.repeatshowid IS NULL) AS second, ( "
-        "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistid = %s AND pm.showpnlrank = '2t' AND "
-        "s.bestof = 0 and s.repeatshowid IS NULL) AS second_tied, ( "
-        "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.panelistid = %s AND pm.showpnlrank = '3' AND "
-        "s.bestof = 0 and s.repeatshowid IS NULL "
-        ") AS third;"
-    )
     cursor.execute(
         query,
         (
@@ -97,7 +96,6 @@ def retrieve_all_panelist_rankings(
     database_connection: mysql.connector.connect,
 ) -> Dict[str, Any]:
     """Returns ranking statistics for all available panelists"""
-
     panelists = common.retrieve_panelists(database_connection=database_connection)
     if not panelists:
         return None

--- a/app/panelists/reports/single_appearance.py
+++ b/app/panelists/reports/single_appearance.py
@@ -1,38 +1,63 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Single Appearance Report Functions"""
 from typing import Any, Dict, List
+
+from flask import current_app
 import mysql.connector
 
 
 def retrieve_single_appearances(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict[str, Any]]:
     """Retrieve a list of panelists that have only made a single
     appearance on the show"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT p.panelist, p.panelistslug, s.showdate,
+            pm.panelistscore_decimal AS score, pm.showpnlrank
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.showpnlmapid IN (
+            SELECT ANY_VALUE(pm.showpnlmapid)
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist
+            HAVING COUNT(p.panelist) = 1 )
+            ORDER BY p.panelist ASC;
+            """
+    else:
+        query = """
+            SELECT p.panelist, p.panelistslug, s.showdate,
+            pm.panelistscore AS score, pm.showpnlrank FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.showpnlmapid IN (
+            SELECT ANY_VALUE(pm.showpnlmapid)
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY p.panelist
+            HAVING COUNT(p.panelist) = 1 )
+            ORDER BY p.panelist ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelist, p.panelistslug, s.showdate, "
-        "pm.panelistscore, pm.showpnlrank FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE pm.showpnlmapid IN ( "
-        "SELECT ANY_VALUE(pm.showpnlmapid) "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY p.panelist "
-        "HAVING COUNT(p.panelist) = 1 ) "
-        "ORDER BY p.panelist ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -47,8 +72,8 @@ def retrieve_single_appearances(
                 "name": row.panelist,
                 "slug": row.panelistslug,
                 "appearance": row.showdate.isoformat(),
-                "score": row.panelistscore,
-                "rank": row.showpnlrank,
+                "score": row.score,
+                "score_decimal" "rank": row.showpnlrank,
             }
         )
 

--- a/app/panelists/reports/stats_summary.py
+++ b/app/panelists/reports/stats_summary.py
@@ -176,18 +176,18 @@ def retrieve_all_panelists_stats(
                 all_stats[panelist_slug]["stats"] = {
                     "minimum": Decimal(numpy.amin(scores)),
                     "maximum": Decimal(numpy.amax(scores)),
-                    "mean": Decimal(numpy.mean(scores)),
+                    "mean": round(Decimal(numpy.mean(scores)), 5),
                     "median": Decimal(numpy.median(scores)),
-                    "standard_deviation": Decimal(numpy.std(scores)),
+                    "standard_deviation": round(Decimal(numpy.std(scores)), 5),
                     "total": Decimal(numpy.sum(scores)),
                 }
             else:
                 all_stats[panelist_slug]["stats"] = {
                     "minimum": int(numpy.amin(scores)),
                     "maximum": int(numpy.amax(scores)),
-                    "mean": round(numpy.mean(scores), 4),
+                    "mean": round(numpy.mean(scores), 5),
                     "median": int(numpy.median(scores)),
-                    "standard_deviation": round(numpy.std(scores), 4),
+                    "standard_deviation": round(numpy.std(scores), 5),
                     "total": int(numpy.sum(scores)),
                 }
         else:

--- a/app/panelists/reports/stats_summary.py
+++ b/app/panelists/reports/stats_summary.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Panelist Statistics Summary Report Functions"""
+from decimal import Decimal
 from typing import Any, Dict, List
 
+from flask import current_app
 import mysql.connector
 import numpy
 
@@ -13,34 +15,62 @@ from . import common
 
 
 def retrieve_appearances_by_panelist(
-    panelist_slug: str, database_connection: mysql.connector.connect
+    panelist_slug: str,
+    database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> Dict[str, int]:
     """Retrieve appearance data for the requested panelist by the
     panelist's slug string"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT (
+            SELECT COUNT(pm.showid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND
+            p.panelistslug = %s ) AS regular, (
+            SELECT COUNT(pm.showid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE p.panelistslug = %s ) AS all_shows, (
+            SELECT COUNT(pm.panelistid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON pm.showid = s.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE p.panelistslug = %s AND s.bestof = 0 AND
+            s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL )
+            AS with_scores;
+            """
+    else:
+        query = """
+            SELECT (
+            SELECT COUNT(pm.showid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND
+            p.panelistslug = %s ) AS regular, (
+            SELECT COUNT(pm.showid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE p.panelistslug = %s ) AS all_shows, (
+            SELECT COUNT(pm.panelistid) FROM ww_showpnlmap pm
+            JOIN ww_shows s ON pm.showid = s.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE p.panelistslug = %s AND s.bestof = 0 AND
+            s.repeatshowid IS NULL
+            AND pm.panelistscore IS NOT NULL )
+            AS with_scores;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT ( "
-        "SELECT COUNT(pm.showid) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND "
-        "p.panelistslug = %s ) AS regular, ( "
-        "SELECT COUNT(pm.showid) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE p.panelistslug = %s ) AS allshows, ( "
-        "SELECT COUNT(pm.panelistid) FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON pm.showid = s.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE p.panelistslug = %s AND s.bestof = 0 AND "
-        "s.repeatshowid IS NULL "
-        "AND pm.panelistscore IS NOT NULL ) "
-        "AS withscores;"
-    )
     cursor.execute(
         query,
         (
@@ -57,29 +87,46 @@ def retrieve_appearances_by_panelist(
 
     return {
         "regular": result.regular,
-        "all": result.allshows,
-        "with_scores": result.withscores,
+        "all": result.all_shows,
+        "with_scores": result.with_scores,
     }
 
 
 def retrieve_scores_by_panelist(
-    panelist_slug: str, database_connection: mysql.connector.connect
+    panelist_slug: str,
+    database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> List[int]:
     """Retrieve all scores for the requested panelist by the panelist's
     slug string"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT pm.panelistscore_decimal AS score FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND p.panelistslug = %s
+            AND pm.panelistscore_decimal IS NOT NULL;
+            """
+    else:
+        query = """
+            SELECT pm.panelistscore AS score FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND p.panelistslug = %s
+            AND pm.panelistscore IS NOT NULL;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT pm.panelistscore FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND p.panelistslug = %s "
-        "AND pm.panelistscore IS NOT NULL;"
-    )
     cursor.execute(query, (panelist_slug,))
     result = cursor.fetchall()
     cursor.close()
@@ -87,14 +134,19 @@ def retrieve_scores_by_panelist(
     if not result:
         return None
 
-    return [row.panelistscore for row in result]
+    return [row.score for row in result]
 
 
 def retrieve_all_panelists_stats(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> Dict[str, Any]:
     """Retrieve appearance and score statistics for all available
     panelists and calculates common statistics for each panelist"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     panelists = common.retrieve_panelists(database_connection=database_connection)
 
@@ -108,22 +160,36 @@ def retrieve_all_panelists_stats(
         panelist_slug = panelist["slug"]
         all_stats[panelist_slug] = {
             "appearances": retrieve_appearances_by_panelist(
-                panelist_slug=panelist_slug, database_connection=database_connection
+                panelist_slug=panelist_slug,
+                database_connection=database_connection,
+                use_decimal_scores=use_decimal_scores,
             ),
         }
 
         scores = retrieve_scores_by_panelist(
-            panelist_slug=panelist_slug, database_connection=database_connection
+            panelist_slug=panelist_slug,
+            database_connection=database_connection,
+            use_decimal_scores=use_decimal_scores,
         )
         if scores:
-            all_stats[panelist_slug]["stats"] = {
-                "minimum": int(numpy.amin(scores)),
-                "maximum": int(numpy.amax(scores)),
-                "mean": round(numpy.mean(scores), 4),
-                "median": int(numpy.median(scores)),
-                "standard_deviation": round(numpy.std(scores), 4),
-                "total": int(numpy.sum(scores)),
-            }
+            if use_decimal_scores:
+                all_stats[panelist_slug]["stats"] = {
+                    "minimum": Decimal(numpy.amin(scores)),
+                    "maximum": Decimal(numpy.amax(scores)),
+                    "mean": Decimal(numpy.mean(scores)),
+                    "median": Decimal(numpy.median(scores)),
+                    "standard_deviation": Decimal(numpy.std(scores)),
+                    "total": Decimal(numpy.sum(scores)),
+                }
+            else:
+                all_stats[panelist_slug]["stats"] = {
+                    "minimum": int(numpy.amin(scores)),
+                    "maximum": int(numpy.amax(scores)),
+                    "mean": round(numpy.mean(scores), 4),
+                    "median": int(numpy.median(scores)),
+                    "standard_deviation": round(numpy.std(scores), 4),
+                    "total": int(numpy.sum(scores)),
+                }
         else:
             all_stats[panelist_slug]["stats"] = None
 

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -64,9 +64,18 @@ def index():
 def aggregate_scores():
     """View: Panelists Aggregate Scores Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _scores = retrieve_all_scores(database_connection=_database_connection)
-    _stats = calculate_stats(_scores)
-    _aggregate = retrieve_score_spread(database_connection=_database_connection)
+    _scores = retrieve_all_scores(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
+    _stats = calculate_stats(
+        _scores,
+        decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
+    _aggregate = retrieve_score_spread(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
     return render_template(
         "panelists/aggregate-scores.html", stats=_stats, aggregate=_aggregate
@@ -107,7 +116,11 @@ def average_scores_by_year():
             # Retrieve average scores for the panelist
             panelist_info = {"slug": panelist, "name": _panelists_info[panelist]}
             average_scores = retrieve_panelist_yearly_average(
-                panelist_slug=panelist, database_connection=_database_connection
+                panelist_slug=panelist,
+                database_connection=_database_connection,
+                use_decimal_scores=current_app.config["app_settings"][
+                    "use_decimal_scores"
+                ],
             )
             _database_connection.close()
             return render_template(
@@ -136,7 +149,8 @@ def average_scores_by_year():
 def average_scores_by_year_all():
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     average_scores = retrieve_all_panelists_yearly_average(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     years = retrieve_all_years(database_connection=_database_connection)
     if average_scores and years:
@@ -175,7 +189,8 @@ def first_appearance_wins():
     """View: Panelists with First Appearance Wins"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists_first_appearance_wins(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
     return render_template(
@@ -201,7 +216,10 @@ def first_most_recent_appearances():
 def gender_stats():
     """View: Panelists Statistics by Gender Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _stats = retrieve_stats_by_year_gender(database_connection=_database_connection)
+    _stats = retrieve_stats_by_year_gender(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
     return render_template("panelists/gender-stats.html", gender_stats=_stats)
 
@@ -316,12 +334,18 @@ def panelist_pvp_scoring():
                     panelist_slug_1=panelist_values[0],
                     panelist_slug_2=panelist_values[1],
                     database_connection=_database_connection,
+                    use_decimal_scores=current_app.config["app_settings"][
+                        "use_decimal_scores"
+                    ],
                 )
                 scores = retrieve_panelists_scores(
                     show_ids=shows,
                     panelist_slug_a=panelist_values[0],
                     panelist_slug_b=panelist_values[1],
                     database_connection=_database_connection,
+                    use_decimal_scores=current_app.config["app_settings"][
+                        "use_decimal_scores"
+                    ],
                 )
                 _database_connection.close()
 
@@ -354,7 +378,10 @@ def panelist_pvp_scoring():
 def perfect_scores():
     """View: Perfect Scores Count Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _counts = retrieve_perfect_score_counts(database_connection=_database_connection)
+    _counts = retrieve_perfect_score_counts(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
     return render_template("panelists/perfect-scores.html", counts=_counts)
 
@@ -378,7 +405,10 @@ def rankings_summary():
 def single_appearance():
     """View: Panelists Single Appearance Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _panelists = retrieve_single_appearances(database_connection=_database_connection)
+    _panelists = retrieve_single_appearances(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
     return render_template(
         "panelists/single-appearance.html",
@@ -392,7 +422,10 @@ def stats_summary():
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
     _panelists_dict = {panelist["slug"]: panelist["name"] for panelist in _panelists}
-    _stats = summary_retrieve_all_stats(database_connection=_database_connection)
+    _stats = summary_retrieve_all_stats(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
     return render_template(
         "panelists/stats-summary.html",

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists Routes for Wait Wait Reports"""
 from flask import Blueprint, current_app, render_template, request

--- a/app/panelists/templates/panelists/_reports.html
+++ b/app/panelists/templates/panelists/_reports.html
@@ -116,10 +116,8 @@
         another panelist on a show-by-show basis.
     </dd>
     <dd>
-        Scoring data is currently available for shows that aired in January
-        2000 through current shows. Best Of, repeat and special shows, including
-        the 20th anniversary show that aired on
-        <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>, will not be
+        Best Of, repeat and special shows, including the 20th anniversary show that
+        aired on <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>, will not be
         included in the results.
     </dd>
 

--- a/app/panelists/templates/panelists/aggregate-scores.html
+++ b/app/panelists/templates/panelists/aggregate-scores.html
@@ -38,6 +38,32 @@
             <td>Count</td>
             <td>{{ stats.count }}</td>
         </tr>
+        {% if use_decimal_scores %}
+        <tr>
+            <td>Minimum</td>
+            <td>{{ "{:f}".format(stats.minimum.normalize()) }}</td>
+        </tr>
+        <tr>
+            <td>Maximum</td>
+            <td>{{ "{:f}".format(stats.maximum.normalize()) }}</td>
+        </tr>
+        <tr>
+            <td>Mean</td>
+            <td>{{ "{:f}".format(stats.mean.normalize()) }}</td>
+        </tr>
+        <tr>
+            <td>Median</td>
+            <td>{{ "{:f}".format(stats.median.normalize()) }}</td>
+        </tr>
+        <tr>
+            <td>Standard Deviation</td>
+            <td>{{ "{:f}".format(stats.standard_deviation.normalize()) }}</td>
+        </tr>
+        <tr>
+            <td>Sum</td>
+            <td>{{ "{:f}".format(stats.sum.normalize()) }}</td>
+        </tr>
+        {% else %}
         <tr>
             <td>Minimum</td>
             <td>{{ stats.minimum }}</td>
@@ -62,6 +88,7 @@
             <td>Sum</td>
             <td>{{ stats.sum }}</td>
         </tr>
+        {% endif %}
     </tbody>
 </table>
 <!-- End Aggregate Score Statistics Section -->
@@ -82,7 +109,11 @@
     <tbody>
     {% for score in aggregate %}
         <tr>
+            {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(score.score.normalize()) }}</td>
+            {% else %}
             <td>{{ score.score }}</td>
+            {% endif %}
             <td>{{ score.count }}</td>
         </tr>
     {% endfor %}

--- a/app/panelists/templates/panelists/average-scores-by-year-all.html
+++ b/app/panelists/templates/panelists/average-scores-by-year-all.html
@@ -49,7 +49,13 @@
             </td>
             {% for year in years %}
                 {% if year in panelist.averages and panelist.averages[year] > 0%}
-            <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">{{ panelist.averages[year] }}</td>
+            <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">
+                {% if use_decimal_scores %}
+                {{ "{:f}".format(panelist.averages[year].normalize()) }}
+                {% else %}
+                {{ panelist.averages[year] }}
+                {% endif %}
+            </td>
                 {% else %}
             <td class="no-data stats float">-</td>
                 {% endif %}

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -67,7 +67,11 @@
         <tr>
             <td>{{ year }}</td>
             {% if average_scores.averages[year] %}
+                {%if use_decimal_scores %}
+            <td>{{ "{:f}".format(average_scores.averages[year].normalize()) }}</td>
+                {% else %}
             <td>{{ average_scores.averages[year] }}</td>
+                {% endif %}
             {% else %}
             <td class="no-data stats float">-</td>
             {% endif %}

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -51,9 +51,21 @@
         <tr>
             <td><a href="{{ stats_url }}/panelists/{{ panelist }}">{{ panelist_info.name }}</a></td>
             <td><a href="{{ stats_url }}/shows/{{ panelist_info.show_date|replace('-', '/') }}">{{ panelist_info.show_date }}</a></td>
+            {% if panelist_info.start %}
             <td>{{ panelist_info.start }}</td>
+            {% else %}
+            <td class="no-data">-</td>
+            {% endif %}
+            {% if panelist_info.correct %}
             <td>{{ panelist_info.correct }}</td>
+            {% else %}
+            <td class="no-data">-</td>
+            {% endif %}
+            {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(panelist_info.score_decimal.normalize()) }}</td>
+            {% else %}
             <td>{{ panelist_info.score }}</td>
+            {% endif %}
             <td>{{ rank_map[panelist_info.rank] }}</td>
         </tr>
         {% endfor %}

--- a/app/panelists/templates/panelists/gender-stats.html
+++ b/app/panelists/templates/panelists/gender-stats.html
@@ -24,6 +24,7 @@
 <table class="pure-table pure-table-bordered">
     <colgroup>
         <col class="date year">
+        {# Men #}
         <col class="stats int">
         <col class="stats int">
         <col class="stats float">
@@ -31,6 +32,7 @@
         <col class="stats float">
         <col class="count">
         <col class="stats int">
+        {# Women #}
         <col class="stats int">
         <col class="stats int">
         <col class="stats float">
@@ -46,7 +48,7 @@
             <th colspan="7">Women</th>
         </tr>
         <tr>
-            <!-- Men -->
+            {# Men #}
             <th scope="col">Min</th>
             <th scope="col">Max</th>
             <th scope="col">Mean</th>
@@ -54,7 +56,7 @@
             <th scope="col">Std Dev</th>
             <th scope="col">Count</th>
             <th scope="col">Sum</th>
-            <!-- Women -->
+            {# Women #}
             <th scope="col">Min</th>
             <th scope="col">Max</th>
             <th scope="col">Mean</th>
@@ -69,6 +71,15 @@
         <tr>
             <td>{{ year }}</td>
             {% if gender_stats[year]["M"] %}
+                {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["minimum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["maximum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["mean"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["median"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["standard_deviation"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["count"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["total"].normalize()) }}</td>
+                {% else %}
             <td>{{ gender_stats[year]["M"]["minimum"] }}</td>
             <td>{{ gender_stats[year]["M"]["maximum"] }}</td>
             <td>{{ gender_stats[year]["M"]["mean"] }}</td>
@@ -76,11 +87,21 @@
             <td>{{ gender_stats[year]["M"]["standard_deviation"] }}</td>
             <td>{{ gender_stats[year]["M"]["count"] }}</td>
             <td>{{ gender_stats[year]["M"]["total"] }}</td>
+                {% endif %}
             {% else %}
             <td class="no-data" colspan="7">-</td>
             {% endif %}
 
             {% if gender_stats[year]["F"] %}
+            {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["minimum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["maximum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["mean"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["median"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["standard_deviation"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["count"].normalize()) }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["total"].normalize()) }}</td>
+                {% else %}
             <td>{{ gender_stats[year]["F"]["minimum"] }}</td>
             <td>{{ gender_stats[year]["F"]["maximum"] }}</td>
             <td>{{ gender_stats[year]["F"]["mean"] }}</td>
@@ -88,6 +109,7 @@
             <td>{{ gender_stats[year]["F"]["standard_deviation"] }}</td>
             <td>{{ gender_stats[year]["F"]["count"] }}</td>
             <td>{{ gender_stats[year]["F"]["total"] }}</td>
+                {% endif %}
             {% else %}
             <td class="no-data" colspan="7">-</td>
             {% endif %}

--- a/app/panelists/templates/panelists/panelist-pvp-scoring.html
+++ b/app/panelists/templates/panelists/panelist-pvp-scoring.html
@@ -17,11 +17,9 @@
     against another panelist, broken down by show.
 </p>
 <p>
-    Scoring data is currently available for shows that aired in January
-    2000 through current shows. Best Of, repeat and special shows, including
-    the 20th anniversary show that aired on
-    <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>, will not be
-    included in the results.
+    Best Of, repeat and special shows, including the 20th anniversary show
+    that aired on <a href="{{ stats_url }}/shows/2018/10/27">2018-10-27</a>,
+    will not be included in the results.
 </p>
 {% endblock synopsis %}
 
@@ -105,24 +103,33 @@
         {% for show in scores %}
         <tr>
             <td><a href="{{ stats_url }}/shows/{{ show|replace('-', '/') }}">{{ show }}</a></td>
+            {% if use_decimal_scores %}
             {% set panelist_1_score = scores[show][request.form.panelist_1].score %}
-            {% set panelist_1_rank = scores[show][request.form.panelist_1].rank %}
             {% set panelist_2_score = scores[show][request.form.panelist_2].score %}
+            {% set panelist_1_score_text = "{:f}".format(scores[show][request.form.panelist_1].score.normalize()) %}
+            {% set panelist_2_score_text = "{:f}".format(scores[show][request.form.panelist_2].score.normalize()) %}
+            {% else %}
+            {% set panelist_1_score = scores[show][request.form.panelist_1].score %}
+            {% set panelist_2_score = scores[show][request.form.panelist_2].score %}
+            {% set panelist_1_score_text = scores[show][request.form.panelist_1].score %}
+            {% set panelist_2_score_text = scores[show][request.form.panelist_2].score %}
+            {% endif %}
+            {% set panelist_1_rank = scores[show][request.form.panelist_1].rank %}
             {% set panelist_2_rank = scores[show][request.form.panelist_2].rank %}
             {% if panelist_1_score > panelist_2_score %}
-            <td class="score-higher">{{ panelist_1_score }}</td>
+            <td class="score-higher">{{ panelist_1_score_text }}</td>
             <td class="rank-higher">{{ rank_map[panelist_1_rank] }}</td>
-            <td class="score-lower">{{ panelist_2_score }}</td>
+            <td class="score-lower">{{ panelist_2_score_text }}</td>
             <td class="rank-lower">{{ rank_map[panelist_2_rank] }}</td>
             {% elif panelist_1_score < panelist_2_score %}
-            <td class="score-lower">{{ panelist_1_score }}</td>
+            <td class="score-lower">{{ panelist_1_score_text }}</td>
             <td class="rank-lower">{{ rank_map[panelist_1_rank] }}</td>
-            <td class="score-higher">{{ panelist_2_score }}</td>
+            <td class="score-higher">{{ panelist_2_score_text }}</td>
             <td class="rank-higher">{{ rank_map[panelist_2_rank] }}</td>
             {% else %}
-            <td class="score-tied">{{ panelist_1_score }}</td>
+            <td class="score-tied">{{ panelist_1_score_text }}</td>
             <td class="rank-tied">{{ rank_map[panelist_1_rank] }}</td>
-            <td class="score-tied">{{ panelist_2_score }}</td>
+            <td class="score-tied">{{ panelist_2_score_text }}</td>
             <td class="rank-tied">{{ rank_map[panelist_2_rank] }}</td>
             {% endif %}
         </tr>

--- a/app/panelists/templates/panelists/perfect-scores.html
+++ b/app/panelists/templates/panelists/perfect-scores.html
@@ -41,7 +41,11 @@
         <tr>
             <td><a href="{{ stats_url }}/panelists/{{ counts[panelist].slug }}">
                 {{ counts[panelist].name }}</a></td>
+            {% if counts[panelist].perfect %}
             <td>{{ counts[panelist].perfect }}</td>
+            {% else %}
+            <td class="no-data">-</td>
+            {% endif %}
             <td>{{ counts[panelist].more_perfect }}</td>
         </tr>
         {% endfor %}

--- a/app/panelists/templates/panelists/single-appearance.html
+++ b/app/panelists/templates/panelists/single-appearance.html
@@ -40,12 +40,22 @@
                 {{ panelist.name }}</a></td>
             <td><a href="{{ stats_url }}/shows/{{ panelist.appearance|replace('-', '/') }}">
                 {{ panelist.appearance }}</a></td>
-            {% if panelist.score and panelist.rank %}
-            <td>{{ panelist.score }} ({{ rank_map[panelist.rank] }})</td>
-            {% elif panelist.score %}
-            <td>{{ panelist.score }}</td>
-            {% else %}
+            {% if use_decimal_scores %}
+                {% if panelist.score and panelist.rank %}
+            <td>{{ "{:f}".format(panelist.score.normalize()) }} ({{ rank_map[panelist.rank] }})</td>
+                {% elif panelist.score %}
+            <td>{{ "{:f}".format(panelist.score.normalize()) }}</td>
+                {% else %}
             <td class="no-data">-</td>
+                {% endif %}
+            {% else %}
+                {% if panelist.score and panelist.rank %}
+            <td>{{ panelist.score }} ({{ rank_map[panelist.rank] }})</td>
+                {% elif panelist.score %}
+            <td>{{ panelist.score }}</td>
+                {% else %}
+            <td class="no-data">-</td>
+                {% endif %}
             {% endif %}
         </tr>
         {% endfor %}

--- a/app/panelists/templates/panelists/stats-summary.html
+++ b/app/panelists/templates/panelists/stats-summary.html
@@ -46,9 +46,9 @@
             <th scope="col">With Scores</th>
             <th scope="col">Min</th>
             <th scope="col">Max</th>
-            <th scope="col">Mean</th>
-            <th scope="col">Median</th>
-            <th scope="col">Std Dev</th>
+            <th scope="col stats float">Mean</th>
+            <th scope="col stats float">Median</th>
+            <th scope="col stats float">Std Dev</th>
             <th scope="col">Sum</th>
         </tr>
     </thead>
@@ -68,12 +68,21 @@
             {% endif %}
 
             {% if panelists_stats[panelist]["stats"] %}
+                {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["minimum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["maximum"].normalize()) }}</td>
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["mean"].normalize()) }}</td>
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["median"].normalize()) }}</td>
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["standard_deviation"].normalize()) }}</td>
+            <td>{{ "{:f}".format(panelists_stats[panelist]["stats"]["total"].normalize()) }}</td>
+                {% else %}
             <td>{{ panelists_stats[panelist]["stats"]["minimum"] }}</td>
             <td>{{ panelists_stats[panelist]["stats"]["maximum"] }}</td>
             <td>{{ panelists_stats[panelist]["stats"]["mean"] }}</td>
             <td>{{ panelists_stats[panelist]["stats"]["median"] }}</td>
             <td>{{ panelists_stats[panelist]["stats"]["standard_deviation"] }}</td>
             <td>{{ panelists_stats[panelist]["stats"]["total"] }}</td>
+                {% endif %}
             {% else %}
             <td class="no-data">-</td>
             <td class="no-data">-</td>

--- a/app/shows/__init__.py
+++ b/app/shows/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Shows module for Wait Wait Reports"""

--- a/app/shows/redirects.py
+++ b/app/shows/redirects.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Redirect Routes for Wait Wait Reports"""
-from crypt import methods
 from flask import Blueprint, url_for
 
 from app.utility import redirect_url

--- a/app/shows/reports/__init__.py
+++ b/app/shows/reports/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Reports module for Wait Wait Reports"""

--- a/app/shows/reports/all_women_panel.py
+++ b/app/shows/reports/all_women_panel.py
@@ -160,7 +160,9 @@ def retrieve_shows_all_women_panel(
     shows = []
     for row in result:
         show_id = row.showid
-        show_details = retrieve_show_details(show_id, database_connection)
+        show_details = retrieve_show_details(
+            show_id, database_connection, use_decimal_scores=use_decimal_scores
+        )
         if show_details:
             shows.append(show_details)
 

--- a/app/shows/reports/guest_host.py
+++ b/app/shows/reports/guest_host.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2022 Linh Pham
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Guest Hosts Report Functions"""
 from typing import List, Dict
@@ -13,25 +15,24 @@ def retrieve_shows_guest_host(
     database_connection: mysql.connector.connect,
 ) -> List[Dict]:
     """Retrieve a list of shows with guest hosts"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, h.host,
+        h.hostslug, sk.scorekeeper, sk.scorekeeperslug,
+        skm.guest as scorekeeper_guest, l.venue, l.city, l.state
+        FROM ww_showhostmap hm
+        JOIN ww_hosts h ON h.hostid = hm.hostid
+        JOIN ww_showskmap skm ON skm.showid = hm.showid
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        JOIN ww_shows s ON s.showid = hm.showid
+        JOIN ww_showlocationmap lm ON lm.showid = hm.showid
+        JOIN ww_locations l ON l.locationid = lm.locationid
+        WHERE hm.guest = 1
+        ORDER BY s.showdate ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, h.host, "
-        "h.hostslug, sk.scorekeeper, sk.scorekeeperslug, "
-        "skm.guest as scorekeeper_guest, l.venue, l.city, l.state "
-        "FROM ww_showhostmap hm "
-        "JOIN ww_hosts h ON h.hostid = hm.hostid "
-        "JOIN ww_showskmap skm ON skm.showid = hm.showid "
-        "JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid "
-        "JOIN ww_shows s ON s.showid = hm.showid "
-        "JOIN ww_showlocationmap lm ON lm.showid = hm.showid "
-        "JOIN ww_locations l ON l.locationid = lm.locationid "
-        "WHERE hm.guest = 1 "
-        "ORDER BY s.showdate ASC "
-    )
     cursor.execute(query)
     result = cursor.fetchall()
 

--- a/app/shows/reports/guest_scorekeeper.py
+++ b/app/shows/reports/guest_scorekeeper.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2022 Linh Pham
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Guest Scorekeeper Report Functions"""
 from typing import List, Dict
@@ -13,25 +15,24 @@ def retrieve_shows_guest_scorekeeper(
     database_connection: mysql.connector.connect,
 ) -> List[Dict]:
     """Retrieve a list of shows with guest scorekeepers"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, h.host,
+        h.hostslug, hm.guest AS host_guest, sk.scorekeeper,
+        sk.scorekeeperslug, l.venue, l.city, l.state
+        FROM ww_showhostmap hm
+        JOIN ww_hosts h ON h.hostid = hm.hostid
+        JOIN ww_showskmap skm ON skm.showid = hm.showid
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        JOIN ww_shows s ON s.showid = hm.showid
+        JOIN ww_showlocationmap lm ON lm.showid = hm.showid
+        JOIN ww_locations l ON l.locationid = lm.locationid
+        WHERE skm.guest = 1
+        ORDER BY s.showdate ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, h.host, "
-        "h.hostslug, hm.guest AS host_guest, sk.scorekeeper, "
-        "sk.scorekeeperslug, l.venue, l.city, l.state "
-        "FROM ww_showhostmap hm "
-        "JOIN ww_hosts h ON h.hostid = hm.hostid "
-        "JOIN ww_showskmap skm ON skm.showid = hm.showid "
-        "JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid "
-        "JOIN ww_shows s ON s.showid = hm.showid "
-        "JOIN ww_showlocationmap lm ON lm.showid = hm.showid "
-        "JOIN ww_locations l ON l.locationid = lm.locationid "
-        "WHERE skm.guest = 1 "
-        "ORDER BY s.showdate ASC "
-    )
     cursor.execute(query)
     result = cursor.fetchall()
 

--- a/app/shows/reports/guests_vs_bluffs.py
+++ b/app/shows/reports/guests_vs_bluffs.py
@@ -134,6 +134,14 @@ def retrieve_not_my_job_stats(
         "total": count_all_guest_scores + len(best_of_only_guest_ids),
         "wins": count_guest_wins + best_of_only_guest_wins,
         "losses": count_guest_losses + best_of_only_guest_losses,
+        "win_ratio": round(
+            100
+            * (
+                (count_guest_wins + best_of_only_guest_wins)
+                / (count_all_guest_scores + len(best_of_only_guest_ids))
+            ),
+            5,
+        ),
     }
 
     return ret_val
@@ -213,4 +221,5 @@ def retrieve_bluff_stats(
         "total": count_unique_bluffs,
         "correct": count_chosen_correct,
         "incorrect": count_chosen_incorrect,
+        "correct_ratio": round(100 * (count_chosen_correct / count_unique_bluffs), 5),
     }

--- a/app/shows/reports/guests_vs_bluffs.py
+++ b/app/shows/reports/guests_vs_bluffs.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2022 Linh Pham
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Not My Job Guest Wins Rate vs Bluff the Listener Wins Rate
 Report Functions"""
 from typing import Any, Dict
 
 import mysql.connector
-
-from app.guests.reports.best_of_only import retrieve_best_of_only_guests
 
 
 def retrieve_not_my_job_stats(
@@ -22,16 +22,16 @@ def retrieve_not_my_job_stats(
 
     # Get a count of all Not My Job guest entries with scores and are
     # from shows that are not Best Of or repeats
+    query = """
+        SELECT COUNT(g.guestid)
+        FROM ww_showguestmap gm
+        JOIN ww_guests g ON g.guestid = gm.guestid
+        JOIN ww_shows s ON  s.showid = gm.showid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+        AND g.guestslug <> 'none'
+        AND gm.guestscore IS NOT NULL;
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(g.guestid) "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_guests g ON g.guestid = gm.guestid "
-        "JOIN ww_shows s ON  s.showid = gm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND g.guestslug <> 'none' "
-        "AND gm.guestscore IS NOT NULL;"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()
@@ -43,16 +43,16 @@ def retrieve_not_my_job_stats(
 
     # Get a count of all Not My Job guest entries in which a guest won
     # outright or was given a win via a scoring exception
+    query = """
+        SELECT COUNT(g.guestid)
+        FROM ww_showguestmap gm
+        JOIN ww_guests g ON g.guestid = gm.guestid
+        JOIN ww_shows s ON s.showid = gm.showid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+        AND g.guestslug <> 'none'
+        AND (gm.guestscore >= 2 OR gm.exception = 1);
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(g.guestid) "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_guests g ON g.guestid = gm.guestid "
-        "JOIN ww_shows s ON s.showid = gm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND g.guestslug <> 'none' "
-        "AND (gm.guestscore >= 2 OR gm.exception = 1);"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()
@@ -64,16 +64,16 @@ def retrieve_not_my_job_stats(
 
     # Get a count of all Not My Job guest entries in which a guest did
     # not win
+    query = """
+        SELECT COUNT(g.guestid)
+        FROM ww_showguestmap gm
+        JOIN ww_guests g ON g.guestid = gm.guestid
+        JOIN ww_shows s ON s.showid = gm.showid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+        AND g.guestslug <> 'none'
+        AND (gm.guestscore < 2 AND gm.exception = 0);
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(g.guestid) "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_guests g ON g.guestid = gm.guestid "
-        "JOIN ww_shows s ON s.showid = gm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND g.guestslug <> 'none' "
-        "AND (gm.guestscore < 2 AND gm.exception = 0);"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()
@@ -85,19 +85,19 @@ def retrieve_not_my_job_stats(
 
     # Get a list of Not My Job guests that have only appeared on Best Of
     # shows
+    query = """
+        SELECT DISTINCT g.guestid
+        FROM ww_showguestmap gm
+        JOIN ww_shows s ON s.showid = gm.showid
+        JOIN ww_guests g ON g.guestid = gm.guestid
+        WHERE s.bestof = 1 AND s.repeatshowid IS NULL
+        AND g.guestid NOT IN (
+        SELECT gm.guestid
+        FROM ww_showguestmap gm
+        JOIN ww_shows s ON s.showid = gm.showid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL );
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT DISTINCT g.guestid "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_shows s ON s.showid = gm.showid "
-        "JOIN ww_guests g ON g.guestid = gm.guestid "
-        "WHERE s.bestof = 1 AND s.repeatshowid IS NULL "
-        "AND g.guestid NOT IN ( "
-        "SELECT gm.guestid "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_shows s ON s.showid = gm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL );"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -110,16 +110,16 @@ def retrieve_not_my_job_stats(
     best_of_only_guest_losses = 0
 
     for guest_id in best_of_only_guest_ids:
+        query = """
+            SELECT s.showdate, gm.guestscore, gm.exception
+            FROM ww_showguestmap gm
+            JOIN ww_shows s ON s.showid = gm.showid
+            WHERE s.repeatshowid IS NULL
+            AND gm.guestid = %s
+            ORDER BY s.showdate ASC
+            LIMIT 1;
+            """
         cursor = database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT s.showdate, gm.guestscore, gm.exception "
-            "FROM ww_showguestmap gm "
-            "JOIN ww_shows s ON s.showid = gm.showid "
-            "WHERE s.repeatshowid IS NULL "
-            "AND gm.guestid = %s "
-            "ORDER BY s.showdate ASC "
-            "LIMIT 1;"
-        )
         cursor.execute(query, (guest_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -150,18 +150,18 @@ def retrieve_bluff_stats(
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT COUNT(s.showid)
+        FROM ww_showbluffmap blm
+        JOIN ww_shows s ON s.showid = blm.showid
+        WHERE
+        (s.bestof = 0 AND blm.chosenbluffpnlid IS NOT NULL AND
+         blm.correctbluffpnlid IS NOT NULL) OR
+        (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
+         blm.chosenbluffpnlid IS NOT NULL AND blm.correctbluffpnlid IS NOT
+         NULL);
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(s.showid) "
-        "FROM ww_showbluffmap blm "
-        "JOIN ww_shows s ON s.showid = blm.showid "
-        "WHERE "
-        "(s.bestof = 0 AND blm.chosenbluffpnlid IS NOT NULL AND "
-        " blm.correctbluffpnlid IS NOT NULL) OR "
-        "(s.bestof = 1 AND s.bestofuniquebluff = 1 AND "
-        " blm.chosenbluffpnlid IS NOT NULL AND blm.correctbluffpnlid IS NOT "
-        " NULL);"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()
@@ -171,16 +171,16 @@ def retrieve_bluff_stats(
 
     count_unique_bluffs = result[0]
 
+    query = """
+        SELECT COUNT(s.showid)
+        FROM ww_showbluffmap blm
+        JOIN ww_shows s ON s.showid = blm.showid
+        WHERE
+        (s.bestof = 0 AND blm.chosenbluffpnlid = blm.correctbluffpnlid) OR
+        (s.bestof = 1 AND s.bestofuniquebluff = 1 AND
+         blm.chosenbluffpnlid = blm.correctbluffpnlid);
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(s.showid) "
-        "FROM ww_showbluffmap blm "
-        "JOIN ww_shows s ON s.showid = blm.showid "
-        "WHERE "
-        "(s.bestof = 0 AND blm.chosenbluffpnlid = blm.correctbluffpnlid) OR "
-        "(s.bestof = 1 AND s.bestofuniquebluff = 1 AND "
-        " blm.chosenbluffpnlid = blm.correctbluffpnlid);"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()
@@ -190,16 +190,16 @@ def retrieve_bluff_stats(
 
     count_chosen_correct = result[0]
 
+    query = """
+        SELECT COUNT(s.showid)
+        FROM ww_showbluffmap blm
+        JOIN ww_shows s ON s.showid = blm.showid
+        WHERE
+        (s.bestof = 0 AND blm.chosenbluffpnlid <> blm.correctbluffpnlid) OR
+        (s.bestof = 1 AND s.bestofuniquebluff = 1 AND blm.chosenbluffpnlid
+         <> blm.correctbluffpnlid);
+        """
     cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT COUNT(s.showid) "
-        "FROM ww_showbluffmap blm "
-        "JOIN ww_shows s ON s.showid = blm.showid "
-        "WHERE "
-        "(s.bestof = 0 AND blm.chosenbluffpnlid <> blm.correctbluffpnlid) OR "
-        "(s.bestof = 1 AND s.bestofuniquebluff = 1 AND blm.chosenbluffpnlid "
-        " <> blm.correctbluffpnlid);"
-    )
     cursor.execute(query)
     result = cursor.fetchone()
     cursor.close()

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -1,17 +1,27 @@
 # -*- coding: utf-8 -*-
+# vim: set noai syntax=python ts=4 sw=4:
+#
 # Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """WWDTM Show Scoring Reports Functions"""
 from typing import List, Dict, Union
 
+from flask import current_app
 import mysql.connector
 
 
 def retrieve_show_details(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int,
+    database_connection: mysql.connector.connect,
+    use_decimal_scores: bool = False,
 ) -> Dict:
     """Retrieves host, scorekeeper, panelist, guest and location
     information for the requested show ID"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -67,13 +77,22 @@ def retrieve_show_details(
         }
 
     # Retrieve panelists and their respective show rank and score
-    query = (
-        "SELECT p.panelist, pm.panelistscore "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE pm.showid = %s "
-        "ORDER BY pm.panelistscore DESC, pm.showpnlrank ASC;"
-    )
+    if use_decimal_scores:
+        query = """
+            SELECT p.panelist, pm.panelistscore, pm.panelistscore_decimal
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE pm.showid = %s
+            ORDER BY pm.panelistscore_decimal DESC, pm.showpnlrank ASC;
+            """
+    else:
+        query = """
+            SELECT p.panelist, pm.panelistscore
+            FROM ww_showpnlmap pm
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE pm.showid = %s
+            ORDER BY pm.panelistscore DESC, pm.showpnlrank ASC;
+            """
     cursor.execute(query, (show_id,))
     result = cursor.fetchall()
     cursor.close()
@@ -83,12 +102,21 @@ def retrieve_show_details(
     else:
         panelists = []
         for row in result:
-            panelists.append(
-                {
-                    "name": row.panelist,
-                    "score": row.panelistscore,
-                }
-            )
+            if use_decimal_scores:
+                panelists.append(
+                    {
+                        "name": row.panelist,
+                        "score": row.panelistscore,
+                        "score_decimal": row.panelistscore_decimal,
+                    }
+                )
+            else:
+                panelists.append(
+                    {
+                        "name": row.panelist,
+                        "score": row.panelistscore,
+                    }
+                )
 
         show_details["panelists"] = panelists
 
@@ -96,24 +124,40 @@ def retrieve_show_details(
 
 
 def retrieve_shows_all_high_scoring(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict]:
     """Retrieves details from shows with a panelist total score greater
     than or equal to 50"""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT s.showid, s.showdate, SUM(pm.panelistscore_decimal) AS total
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY s.showid
+            HAVING SUM(pm.panelistscore_decimal) >= 50
+            ORDER BY SUM(pm.panelistscore_decimal) DESC, s.showdate DESC;
+            """
+    else:
+        query = """
+            SELECT s.showid, s.showdate, SUM(pm.panelistscore) AS total
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            GROUP BY s.showid
+            HAVING SUM(pm.panelistscore) >= 50
+            ORDER BY SUM(pm.panelistscore) DESC, s.showdate DESC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, SUM(pm.panelistscore) AS total "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "GROUP BY s.showid "
-        "HAVING SUM(pm.panelistscore) >= 50 "
-        "ORDER BY SUM(pm.panelistscore) DESC, s.showdate DESC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -124,7 +168,9 @@ def retrieve_shows_all_high_scoring(
     shows = []
     for row in result:
         show_id = row.showid
-        show_details = retrieve_show_details(show_id, database_connection)
+        show_details = retrieve_show_details(
+            show_id, database_connection, use_decimal_scores=use_decimal_scores
+        )
         show_details["total_score"] = row.total
         if show_details:
             shows.append(show_details)
@@ -133,26 +179,43 @@ def retrieve_shows_all_high_scoring(
 
 
 def retrieve_shows_all_low_scoring(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict]:
     """Retrieves details from shows with a panelist total score less
     than 30. Excludes the 20th anniversary show due to unique Lightning
     Fill-in-the-Blank segment."""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT s.showid, s.showdate, SUM(pm.panelistscore_decimal) AS total
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND s.showdate <> '2018-10-27'
+            GROUP BY s.showid
+            HAVING SUM(pm.panelistscore_decimal) < 30
+            ORDER BY SUM(pm.panelistscore_decimal) ASC, s.showdate DESC;
+            """
+    else:
+        query = """
+            SELECT s.showid, s.showdate, SUM(pm.panelistscore) AS total
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+            AND s.showdate <> '2018-10-27'
+            GROUP BY s.showid
+            HAVING SUM(pm.panelistscore) < 30
+            ORDER BY SUM(pm.panelistscore) ASC, s.showdate DESC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, SUM(pm.panelistscore) AS total "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND s.showdate <> '2018-10-27' "
-        "GROUP BY s.showid "
-        "HAVING SUM(pm.panelistscore) < 30 "
-        "ORDER BY SUM(pm.panelistscore) ASC, s.showdate DESC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -163,7 +226,9 @@ def retrieve_shows_all_low_scoring(
     shows = []
     for row in result:
         show_id = row.showid
-        show_details = retrieve_show_details(show_id, database_connection)
+        show_details = retrieve_show_details(
+            show_id, database_connection, use_decimal_scores=use_decimal_scores
+        )
         show_details["total_score"] = row.total
         if show_details:
             shows.append(show_details)
@@ -172,28 +237,46 @@ def retrieve_shows_all_low_scoring(
 
 
 def retrieve_shows_panelist_score_sum_match(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict]:
     """Retrieves shows in which the score of panelist in first place
     matches the sum of the scores for the other two panelists. Excludes
     the 20th anniversary show due to unique Lightning Fill-in-the-Blank
     segment."""
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
 
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    if use_decimal_scores:
+        query = """
+            SELECT s.showdate, pm.panelistid, p.panelist, p.panelistslug,
+            pm.panelistscore, pm.panelistscore_decimal, pm.showpnlrank
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND
+            s.showdate <> '2018-10-27' AND
+            pm.panelistscore_decimal IS NOT NULL
+            ORDER BY s.showdate ASC, pm.panelistscore_decimal DESC;
+            """
+    else:
+        query = """
+            SELECT s.showdate, pm.panelistid, p.panelist, p.panelistslug,
+            pm.panelistscore, pm.showpnlrank
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND
+            s.showdate <> '2018-10-27' AND
+            pm.panelistscore IS NOT NULL
+            ORDER BY s.showdate ASC, pm.panelistscore DESC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showdate, pm.panelistid, p.panelist, p.panelistslug, "
-        "pm.panelistscore, pm.showpnlrank "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND "
-        "s.showdate <> '2018-10-27' AND "
-        "pm.panelistscore IS NOT NULL "
-        "ORDER BY s.showdate ASC, pm.panelistscore DESC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -207,47 +290,85 @@ def retrieve_shows_panelist_score_sum_match(
         if show_date not in shows:
             shows[show_date] = []
 
-        shows[show_date].append(
-            {
-                "panelist_id": row.panelistid,
-                "panelist": row.panelist,
-                "panelist_slug": row.panelistslug,
-                "score": row.panelistscore,
-                "rank": row.showpnlrank,
-            }
-        )
+        if use_decimal_scores:
+            shows[show_date].append(
+                {
+                    "panelist_id": row.panelistid,
+                    "panelist": row.panelist,
+                    "panelist_slug": row.panelistslug,
+                    "score": row.panelistscore,
+                    "score_decimal": row.panelistscore_decimal,
+                    "rank": row.showpnlrank,
+                }
+            )
+        else:
+            shows[show_date].append(
+                {
+                    "panelist_id": row.panelistid,
+                    "panelist": row.panelist,
+                    "panelist_slug": row.panelistslug,
+                    "score": row.panelistscore,
+                    "rank": row.showpnlrank,
+                }
+            )
 
     shows_match = {}
     for show in shows:
-        show_info = shows[show]
-        score_1 = show_info[0]["score"]
-        score_2 = show_info[1]["score"]
-        score_3 = show_info[2]["score"]
-        if score_1 == score_2 + score_3:
-            shows_match[show] = show_info
+        if use_decimal_scores:
+            show_info = shows[show]
+            score_1 = show_info[0]["score_decimal"]
+            score_2 = show_info[1]["score_decimal"]
+            score_3 = show_info[2]["score_decimal"]
+            if score_1 == score_2 + score_3:
+                shows_match[show] = show_info
+        else:
+            show_info = shows[show]
+            score_1 = show_info[0]["score"]
+            score_2 = show_info[1]["score"]
+            score_3 = show_info[2]["score"]
+            if score_1 == score_2 + score_3:
+                shows_match[show] = show_info
 
     return shows_match
 
 
 def retrieve_shows_panelist_perfect_scores(
-    database_connection: mysql.connector.connect,
+    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
 ) -> List[Dict[str, Union[str, int]]]:
+    if (
+        use_decimal_scores
+        and not current_app.config["app_settings"]["has_decimal_scores_column"]
+    ):
+        return None
+
     if not database_connection.is_connected():
         database_connection.reconnect()
 
     """Retrieves shows in which a panelist scores a total of 20 points,
     or higher. Best Of and repeat shows are excluded."""
+    if use_decimal_scores:
+        query = """
+            SELECT s.showdate, p.panelist, p.panelistslug,
+            pm.panelistscore, pm.panelistscore_decimal
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE pm.panelistscore_decimal >= 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            ORDER BY s.showdate ASC;
+            """
+    else:
+        query = """
+            SELECT s.showdate, p.panelist, p.panelistslug,
+            pm.panelistscore
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            JOIN ww_panelists p ON p.panelistid = pm.panelistid
+            WHERE pm.panelistscore >= 20
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            ORDER BY s.showdate ASC;
+            """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showdate, p.panelist, p.panelistslug, "
-        "pm.panelistscore "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_shows s ON s.showid = pm.showid "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE pm.panelistscore >= 20 "
-        "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-        "ORDER BY s.showdate ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
 
@@ -256,13 +377,24 @@ def retrieve_shows_panelist_perfect_scores(
 
     shows = []
     for row in result:
-        shows.append(
-            {
-                "date": row.showdate,
-                "panelist": row.panelist,
-                "panelist_slug": row.panelistslug,
-                "score": row.panelistscore,
-            }
-        )
+        if use_decimal_scores:
+            shows.append(
+                {
+                    "date": row.showdate,
+                    "panelist": row.panelist,
+                    "panelist_slug": row.panelistslug,
+                    "score": row.panelistscore,
+                    "score_decimal": row.panelistscore_decimal,
+                }
+            )
+        else:
+            shows.append(
+                {
+                    "date": row.showdate,
+                    "panelist": row.panelist,
+                    "panelist_slug": row.panelistslug,
+                    "score": row.panelistscore,
+                }
+            )
 
     return shows

--- a/app/shows/reports/show_details.py
+++ b/app/shows/reports/show_details.py
@@ -13,17 +13,16 @@ def retrieve_show_guests(
     show_id: int, database_connection: mysql.connector.connect
 ) -> List[Dict[str, str]]:
     """Retrieve the Not My Job guest for the requested show ID"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT g.guestid, g.guest, g.guestslug
+        FROM ww_showguestmap gm
+        JOIN ww_guests g on g.guestid = gm.guestid
+        WHERE gm.showid = %s;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT g.guestid, g.guest, g.guestslug "
-        "FROM ww_showguestmap gm "
-        "JOIN ww_guests g on g.guestid = gm.guestid "
-        "WHERE gm.showid = %s;"
-    )
     cursor.execute(query, (show_id,))
     result = cursor.fetchall()
     cursor.close()
@@ -48,18 +47,17 @@ def retrieve_show_panelists(
     show_id: int, database_connection: mysql.connector.connect
 ) -> List[Dict[str, str]]:
     """Retrieve panelists for the requested show ID"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT p.panelistid, p.panelist, p.panelistslug
+        FROM ww_showpnlmap pm
+        JOIN ww_panelists p ON p.panelistid = pm.panelistid
+        WHERE pm.showid = %s
+        ORDER BY pm.showpnlmapid ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT p.panelistid, p.panelist, p.panelistslug "
-        "FROM ww_showpnlmap pm "
-        "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
-        "WHERE pm.showid = %s "
-        "ORDER BY pm.showpnlmapid ASC;"
-    )
     cursor.execute(query, (show_id,))
     result = cursor.fetchall()
     cursor.close()
@@ -85,24 +83,23 @@ def retrieve_all_shows(
 ) -> List[Dict[str, Any]]:
     """Retrieve a list of all shows and basic information including:
     location, host, scorekeeper, panelists and guest"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT s.showid, s.showdate, s.bestof, s.repeatshowid,
+        l.venue, l.city, l.state, h.host, sk.scorekeeper
+        FROM ww_shows s
+        JOIN ww_showlocationmap lm ON lm.showid = s.showid
+        JOIN ww_locations l on l.locationid = lm.locationid
+        JOIN ww_showhostmap hm ON hm.showid = s.showid
+        JOIN ww_hosts h on h.hostid = hm.hostid
+        JOIN ww_showskmap skm ON skm.showid = s.showid
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        AND s.showdate < NOW()
+        ORDER BY s.showdate ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, "
-        "l.venue, l.city, l.state, h.host, sk.scorekeeper "
-        "FROM ww_shows s "
-        "JOIN ww_showlocationmap lm ON lm.showid = s.showid "
-        "JOIN ww_locations l on l.locationid = lm.locationid "
-        "JOIN ww_showhostmap hm ON hm.showid = s.showid "
-        "JOIN ww_hosts h on h.hostid = hm.hostid "
-        "JOIN ww_showskmap skm ON skm.showid = s.showid "
-        "JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid "
-        "AND s.showdate < NOW() "
-        "ORDER BY s.showdate ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()
@@ -146,25 +143,24 @@ def retrieve_all_original_shows(
 ) -> List[Dict[str, Any]]:
     """Retrieve a list of all original shows and basic information
     including: location, host, scorekeeper, panelists and guest"""
-
     if not database_connection.is_connected():
         database_connection.reconnect()
 
+    query = """
+        SELECT s.showid, s.showdate, l.venue, l.city, l.state,
+        h.host, sk.scorekeeper
+        FROM ww_shows s
+        JOIN ww_showlocationmap lm ON lm.showid = s.showid
+        JOIN ww_locations l on l.locationid = lm.locationid
+        JOIN ww_showhostmap hm ON hm.showid = s.showid
+        JOIN ww_hosts h on h.hostid = hm.hostid
+        JOIN ww_showskmap skm ON skm.showid = s.showid
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
+        AND s.showdate < NOW()
+        ORDER BY s.showdate ASC;
+        """
     cursor = database_connection.cursor(named_tuple=True)
-    query = (
-        "SELECT s.showid, s.showdate, l.venue, l.city, l.state, "
-        "h.host, sk.scorekeeper "
-        "FROM ww_shows s "
-        "JOIN ww_showlocationmap lm ON lm.showid = s.showid "
-        "JOIN ww_locations l on l.locationid = lm.locationid "
-        "JOIN ww_showhostmap hm ON hm.showid = s.showid "
-        "JOIN ww_hosts h on h.hostid = hm.hostid "
-        "JOIN ww_showskmap skm ON skm.showid = s.showid "
-        "JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid "
-        "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
-        "AND s.showdate < NOW() "
-        "ORDER BY s.showdate ASC;"
-    )
     cursor.execute(query)
     result = cursor.fetchall()
     cursor.close()

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -70,7 +70,10 @@ def all_shows():
 def all_women_panel():
     """View: All Women Panel Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = retrieve_shows_all_women_panel(database_connection=_database_connection)
+    _shows = retrieve_shows_all_women_panel(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template("shows/all-women-panel.html", shows=_shows)
@@ -110,7 +113,10 @@ def guest_scorekeeper():
 def high_scoring():
     """View: High Scoring Shows Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = retrieve_shows_all_high_scoring(database_connection=_database_connection)
+    _shows = retrieve_shows_all_high_scoring(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template("shows/high-scoring.html", shows=_shows)
@@ -121,7 +127,8 @@ def highest_score_equals_sum_other_scores():
     """View: Highest Score Equals the Sum of Other Scores Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_panelist_score_sum_match(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
 
@@ -134,7 +141,10 @@ def highest_score_equals_sum_other_scores():
 def lightning_round_ending_three_way_tie():
     """View: Lightning Round Ending in a Three-Way Tie Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = shows_ending_with_three_way_tie(database_connection=_database_connection)
+    _shows = shows_ending_with_three_way_tie(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template(
@@ -148,7 +158,8 @@ def lightning_round_starting_ending_three_way_tie():
     Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_starting_ending_three_way_tie(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
 
@@ -173,7 +184,10 @@ def lightning_round_starting_three_way_tie():
 def lightning_round_starting_zero_points():
     """View: Lightning Round Starting with Zero Points Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = shows_lightning_round_start_zero(database_connection=_database_connection)
+    _shows = shows_lightning_round_start_zero(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template(
@@ -186,7 +200,8 @@ def lightning_round_zero_correct():
     """View: Lightning Round with Zero Correct Answers Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_zero_correct(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
 
@@ -197,7 +212,10 @@ def lightning_round_zero_correct():
 def low_scoring():
     """View: Low Scoring Shows Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = retrieve_shows_all_low_scoring(database_connection=_database_connection)
+    _shows = retrieve_shows_all_low_scoring(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template("shows/low-scoring.html", shows=_shows)
@@ -210,16 +228,6 @@ def not_my_job_vs_bluffs():
     _guest_stats = retrieve_not_my_job_stats(database_connection=_database_connection)
     _bluff_stats = retrieve_bluff_stats(database_connection=_database_connection)
     _database_connection.close()
-
-    if "total" in _guest_stats and "wins" in _guest_stats:
-        _guest_stats["win_ratio"] = round(
-            100 * (_guest_stats["wins"] / _guest_stats["total"]), 4
-        )
-
-    if "total" in _bluff_stats and "correct" in _bluff_stats:
-        _bluff_stats["correct_ratio"] = round(
-            100 * (_bluff_stats["correct"] / _bluff_stats["total"]), 4
-        )
 
     return render_template(
         "shows/guests-vs-bluffs.html",
@@ -265,7 +273,8 @@ def perfect_panelist_scores():
     """View: Shows with Perfect Panelist Scores Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_panelist_perfect_scores(
-        database_connection=_database_connection
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
     )
     _database_connection.close()
 

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Routes for Wait Wait Reports"""
-from typing import Optional
-
 from flask import Blueprint, current_app, render_template, request
 import mysql.connector
 

--- a/app/shows/templates/shows/all-women-panel.html
+++ b/app/shows/templates/shows/all-women-panel.html
@@ -57,8 +57,13 @@
                 <ul class="no-bullets">
                 {% for panelist in show.panelists %}
                     <li>
-                    {% if show.guest.score %}
-                    {{ panelist.name }}: {{ panelist.score }}
+                    {% if panelist.score %}
+                    {{ panelist.name }}:
+                        {% if use_decimal_scores %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
+                        {% else %}
+                    {{ panelist.score }}
+                        {% endif %}
                     {% else %}
                     {{ panelist.name }}
                     {% endif %}

--- a/app/shows/templates/shows/high-scoring.html
+++ b/app/shows/templates/shows/high-scoring.html
@@ -45,7 +45,13 @@
     <tbody>
         {% for show in shows %}
         <tr>
-            <td>{{ show.total_score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.total_score.normalize()) }}
+            {% else %}
+            {{ show.total_score }}
+            {% endif %}
+            </td>
             <td><a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">{{ show.date }}</a></td>
             {% if show.location.venue and show.location.city and show.location.city %}
             <td>{{ show.location.venue }} ({{ show.location.city }}, {{ show.location.state }})</td>
@@ -61,15 +67,29 @@
             <td>
                 <ul class="no-bullets">
                 {% for panelist in show.panelists %}
-                    <li>{{ panelist.name }}: {{ panelist.score }}</li>
+                    <li>{{ panelist.name }}:
+                    {% if use_decimal_scores %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
+                    {% else %}
+                    {{ panelist.score }}
+                    {% endif %}
+                    </li>
                 {% endfor %}
                 </ul>
             </td>
+            {% if show.guests %}
             <td>
-                {{ show.guest.name }}: {{ show.guest.score }}
-                {% if show.guest.exception %}
-                *
-                {% endif %}
+                <ul class="no-bullets">
+                    {% for guest in show.guests %}
+                    <li>{{ guest.name }}: {{ guest.score }}
+                    {% if guest.exception %} *{% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </td>
+            {% else %}
+            <td class="no-data">-</td>
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>

--- a/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
+++ b/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
@@ -43,7 +43,11 @@
                 {{ shows[show][0]["panelist"] }}
             </td>
             <td>
+                {% if use_decimal_scores %}
+                {{ "{:f}".format(shows[show][0]["score_decimal"].normalize()) }}
+                {% else %}
                 {{ shows[show][0]["score"] }}
+                {% endif %}
             </td>
             <td>
                 {{ rank_map[shows[show][0]["rank"]] }}
@@ -54,7 +58,11 @@
                 {{ shows[show][1]["panelist"] }}
             </td>
             <td>
+                {% if use_decimal_scores %}
+                {{ "{:f}".format(shows[show][1]["score_decimal"].normalize()) }}
+                {% else %}
                 {{ shows[show][1]["score"] }}
+                {% endif %}
             </td>
             <td>
                 {{ rank_map[shows[show][1]["rank"]] }}
@@ -65,7 +73,11 @@
                 {{ shows[show][2]["panelist"] }}
             </td>
             <td>
+                {% if use_decimal_scores %}
+                {{ "{:f}".format(shows[show][2]["score_decimal"].normalize()) }}
+                {% else %}
                 {{ shows[show][2]["score"] }}
+                {% endif %}
             </td>
             <td>
                 {{ rank_map[shows[show][2]["rank"]] }}

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -44,7 +44,13 @@
                 {% endfor %}
                 </ul>
             </td>
-            <td>{{ show.score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.score_decimal.normalize()) }}
+            {% else %}
+            {{ show.score }}
+            {% endif %}
+            </td>
         </tr>
         {% endfor %}
     </tbody>

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -51,7 +51,13 @@
             </td>
             <td>{{ show.start }}</td>
             <td>{{ show.correct }}</td>
-            <td>{{ show.score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.score_decimal.normalize()) }}
+            {% else %}
+            {{ show.score }}
+            {% endif %}
+            </td>
         </tr>
         {% endfor %}
     </tbody>

--- a/app/shows/templates/shows/lightning-round-starting-zero-points.html
+++ b/app/shows/templates/shows/lightning-round-starting-zero-points.html
@@ -46,7 +46,13 @@
             <td>{{ show.panelist.name }}</td>
             <td>{{ show.panelist.start }}</td>
             <td>{{ show.panelist.correct }}</td>
-            <td>{{ show.panelist.score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.panelist.score_decimal.normalize()) }}
+            {% else %}
+            {{ show.panelist.score }}
+            {% endif %}
+            </td>
             <td>{{ rank_map[show.panelist.rank] }}</td>
         </tr>
         {% endfor %}

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -46,7 +46,13 @@
             <td>{{ show.panelist.name }}</td>
             <td>{{ show.panelist.start }}</td>
             <td>{{ show.panelist.correct }}</td>
-            <td>{{ show.panelist.score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.panelist.score_decimal.normalize()) }}
+            {% else %}
+            {{ show.panelist.score }}
+            {% endif %}
+            </td>
             <td>{{ rank_map[show.panelist.rank] }}</td>
         </tr>
         {% endfor %}

--- a/app/shows/templates/shows/low-scoring.html
+++ b/app/shows/templates/shows/low-scoring.html
@@ -48,7 +48,13 @@
     <tbody>
         {% for show in shows %}
         <tr>
-            <td>{{ show.total_score }}</td>
+            <td>
+            {% if use_decimal_scores %}
+            {{ "{:f}".format(show.total_score.normalize()) }}
+            {% else %}
+            {{ show.total_score }}
+            {% endif %}
+            </td>
             <td><a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">{{ show.date }}</a></td>
             {% if show.location.venue and show.location.city and show.location.city %}
             <td>{{ show.location.venue }} ({{ show.location.city }}, {{ show.location.state }})</td>
@@ -64,15 +70,29 @@
             <td>
                 <ul class="no-bullets">
                 {% for panelist in show.panelists %}
-                    <li>{{ panelist.name }}: {{ panelist.score }}</li>
+                    <li>{{ panelist.name }}:
+                    {% if use_decimal_scores %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
+                    {% else %}
+                    {{ panelist.score }}
+                    {% endif %}
+                    </li>
                 {% endfor %}
                 </ul>
             </td>
+            {% if show.guests %}
             <td>
-                {{ show.guest.name }}: {{ show.guest.score }}
-                {% if show.guest.exception %}
-                *
-                {% endif %}
+                <ul class="no-bullets">
+                    {% for guest in show.guests %}
+                    <li>{{ guest.name }}: {{ guest.score }}
+                    {% if guest.exception %} *{% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </td>
+            {% else %}
+            <td class="no-data">-</td>
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>

--- a/app/shows/templates/shows/perfect-panelist-scores.html
+++ b/app/shows/templates/shows/perfect-panelist-scores.html
@@ -21,6 +21,10 @@
     The list also includes shows where a panelist has a total score greater
     than 20 points.
 </p>
+<p>
+    Note: Shows that aired in 1998 used a different show format and scoring
+    system compared to the current show format and scoring system.
+</p>
 {% endblock synopsis %}
 
 {% block content %}
@@ -44,9 +48,17 @@
             <td><a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">{{ show.date }}</a></td>
             <td>{{ show.panelist }}</td>
             {% if show.score > 20 %}
+                {% if use_decimal_scores %}
+            <td><b>{{ "{:f}".format(show.score_decimal.normalize()) }}</b></td>
+                {% else %}
             <td><b>{{ show.score }}</b></td>
+                {% endif %}
+            {% else %}
+            {% if use_decimal_scores %}
+            <td>{{ "{:f}".format(show.score_decimal.normalize()) }}</td>
             {% else %}
             <td>{{ show.score }}</td>
+            {% endif %}
             {% endif %}
         </tr>
         {% endfor %}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -110,8 +110,12 @@
         width: 6rem;
     }
 
-    col.count.mix, col.date, col.rank, col.stats.float {
+    col.count.mix, col.date, col.stats.float {
         width: 8rem;
+    }
+
+    col.rank {
+        width: 9rem;
     }
 
     col.city, col.score.long {

--- a/app/utility.py
+++ b/app/utility.py
@@ -6,6 +6,7 @@
 """Utility functions used by the Wait Wait Reports"""
 
 from datetime import datetime
+from decimal import Decimal
 from functools import cmp_to_key
 import json
 from typing import Dict, List

--- a/app/utility.py
+++ b/app/utility.py
@@ -117,13 +117,13 @@ def time_zone_parser(time_zone: str) -> pytz.timezone:
     return time_zone_object, time_zone_string
 
 
-def panelist_decimal_score_exists() -> bool:
+def panelist_decimal_score_exists(database_settings: Dict) -> bool:
     """Checks to see if the panelistscore_decimal column exists in the
     ww_showpnlmap table in the Wait Wait Stats Database and returns
     a bool reflecting the results"""
 
     try:
-        database_connection = connect(**current_app.config["database"])
+        database_connection = connect(**database_settings)
         cursor = database_connection.cursor()
         query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal'"
         cursor.execute(query)

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Utility functions used by the Wait Wait Reports"""
 
@@ -13,6 +13,7 @@ from typing import Dict, List
 from dateutil import parser
 from flask import current_app
 import markdown
+from mysql.connector import connect, DatabaseError
 from operator import itemgetter
 import pytz
 
@@ -114,3 +115,23 @@ def time_zone_parser(time_zone: str) -> pytz.timezone:
         time_zone_string = time_zone_object.zone
 
     return time_zone_object, time_zone_string
+
+
+def panelist_decimal_score_exists() -> bool:
+    """Checks to see if the panelistscore_decimal column exists in the
+    ww_showpnlmap table in the Wait Wait Stats Database and returns
+    a bool reflecting the results"""
+
+    try:
+        database_connection = connect(**current_app.config["database"])
+        cursor = database_connection.cursor()
+        query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal'"
+        cursor.execute(query)
+        result = cursor.fetchone()
+        cursor.close()
+        if result:
+            return True
+        else:
+            return False
+    except DatabaseError:
+        return False

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.3.1"
+APP_VERSION = "2.4.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -22,6 +22,7 @@
         "ga_property_code": null,
         "time_zone": "UTC",
         "mastodon_url": "",
-        "mastodon_user": ""
+        "mastodon_user": "",
+        "use_decimal_scores": false
     }
 }

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
-# reports.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2023 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
 """pytest conftest.py File"""
 from flask import Flask
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-required-version = "23.3.0"
+required-version = "23.7.0"
 target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.pytest.ini_options]

--- a/reports.py
+++ b/reports.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Application Bootstrap Script for Wait Wait Reports"""
 from app import create_app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 flake8==6.0.0
 pycodestyle==2.10.0
 pytest==7.3.1
-black==23.3.0
+black==23.7.0
 
 Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 mysql-connector-python==8.0.33
-numpy==1.24.2
+numpy==1.24.3
 python-dateutil==2.8.2
 pytz==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 mysql-connector-python==8.0.33
-numpy==1.24.2
+numpy==1.24.3
 python-dateutil==2.8.2
 pytz==2023.3


### PR DESCRIPTION
## Application Changes

- Add support for the new decimal panelist score column, `panelistscore_decimal` in the `ww_showpnlmap` table of the Wait Wait Stats Database.
- Add a `use_decimal_scores` setting in `config.json` to enable or disable pulling data from the new column. The default is `false`
- All calculations that use of decimal scores, versus integer scores, use the Python Decimal data type
- Change the rounding of certain stats from 4 decimal places to 5 decimal places

## Component Changes

- Upgrade NumPy from 1.24.2 to 1.24.3

## Development Changes

- Upgrade black from 23.3.0 to 23.7.0