### PR TITLE
Add support for panelist Lightning start/correct decimal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changes
 
+## 2.5.0
+
+### Application Changes
+
+- Add support for the new decimal panelist Lightning Fill-in-the-Blank start and correct columns, `panelistlrndstart_decimal` and `panelistlrndcorrect_decimal`, respectively
+- Optimize some of the template checks for `use_decimal_scores`
+
 ## 2.4.0
 
 ### Application Changes
 
-- Add support for the new decimal panelist score column, `panelistscore_decimal` in the `ww_showpnlmap` table of the Wait Wait Stats Database.
+- Add support for the new decimal panelist score column, `panelistscore_decimal` in the `ww_showpnlmap` table of the Wait Wait Stats Database
 - Add a `use_decimal_scores` setting in `config.json` to enable or disable pulling data from the new column. The default is `false`
 - All calculations that use of decimal scores, versus integer scores, use the Python Decimal data type
 - Change the rounding of certain stats from 4 decimal places to 5 decimal places

--- a/app/panelists/templates/panelists/aggregate-scores.html
+++ b/app/panelists/templates/panelists/aggregate-scores.html
@@ -38,57 +38,30 @@
             <td>Count</td>
             <td>{{ stats.count }}</td>
         </tr>
-        {% if use_decimal_scores %}
         <tr>
             <td>Minimum</td>
-            <td>{{ "{:f}".format(stats.minimum.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.minimum.normalize()) if use_decimal_scores else stats.minimum }}</td>
         </tr>
         <tr>
             <td>Maximum</td>
-            <td>{{ "{:f}".format(stats.maximum.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.maximum.normalize()) if use_decimal_scores else stats.maximum }}</td>
         </tr>
         <tr>
             <td>Mean</td>
-            <td>{{ "{:f}".format(stats.mean.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.mean.normalize()) if use_decimal_scores else stats.mean }}</td>
         </tr>
         <tr>
             <td>Median</td>
-            <td>{{ "{:f}".format(stats.median.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.median.normalize()) if use_decimal_scores else stats.median }}</td>
         </tr>
         <tr>
             <td>Standard Deviation</td>
-            <td>{{ "{:f}".format(stats.standard_deviation.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.standard_deviation.normalize()) if use_decimal_scores else stats.standard_deviation }}</td>
         </tr>
         <tr>
             <td>Sum</td>
-            <td>{{ "{:f}".format(stats.sum.normalize()) }}</td>
+            <td>{{ "{:f}".format(stats.sum.normalize()) if use_decimal_scores else stats.sum }}</td>
         </tr>
-        {% else %}
-        <tr>
-            <td>Minimum</td>
-            <td>{{ stats.minimum }}</td>
-        </tr>
-        <tr>
-            <td>Maximum</td>
-            <td>{{ stats.maximum }}</td>
-        </tr>
-        <tr>
-            <td>Mean</td>
-            <td>{{ stats.mean }}</td>
-        </tr>
-        <tr>
-            <td>Median</td>
-            <td>{{ stats.median }}</td>
-        </tr>
-        <tr>
-            <td>Standard Deviation</td>
-            <td>{{ stats.standard_deviation }}</td>
-        </tr>
-        <tr>
-            <td>Sum</td>
-            <td>{{ stats.sum }}</td>
-        </tr>
-        {% endif %}
     </tbody>
 </table>
 <!-- End Aggregate Score Statistics Section -->
@@ -109,11 +82,7 @@
     <tbody>
     {% for score in aggregate %}
         <tr>
-            {% if use_decimal_scores %}
-            <td>{{ "{:f}".format(score.score.normalize()) }}</td>
-            {% else %}
-            <td>{{ score.score }}</td>
-            {% endif %}
+            <td>{{ "{:f}".format(score.score.normalize()) if use_decimal_scores else score.score }}</td>
             <td>{{ score.count }}</td>
         </tr>
     {% endfor %}

--- a/app/panelists/templates/panelists/average-scores-by-year-all.html
+++ b/app/panelists/templates/panelists/average-scores-by-year-all.html
@@ -50,11 +50,7 @@
             {% for year in years %}
                 {% if year in panelist.averages and panelist.averages[year] > 0%}
             <td class="centered middle stats float" title="{{ panelist.name }}: {{ year }}">
-                {% if use_decimal_scores %}
-                {{ "{:f}".format(panelist.averages[year].normalize()) }}
-                {% else %}
-                {{ panelist.averages[year] }}
-                {% endif %}
+                {{ "{:f}".format(panelist.averages[year].normalize()) if use_decimal_scores else panelist.averages[year] }}
             </td>
                 {% else %}
             <td class="no-data stats float">-</td>

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -67,11 +67,7 @@
         <tr>
             <td>{{ year }}</td>
             {% if average_scores.averages[year] %}
-                {%if use_decimal_scores %}
-            <td>{{ "{:f}".format(average_scores.averages[year].normalize()) }}</td>
-                {% else %}
-            <td>{{ average_scores.averages[year] }}</td>
-                {% endif %}
+            <td>{{ "{:f}".format(average_scores.averages[year].normalize()) if use_decimal_scores else average_scores.averages[year] }}</td>
             {% else %}
             <td class="no-data stats float">-</td>
             {% endif %}

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -61,11 +61,7 @@
             {% else %}
             <td class="no-data">-</td>
             {% endif %}
-            {% if use_decimal_scores %}
-            <td>{{ "{:f}".format(panelist_info.score_decimal.normalize()) }}</td>
-            {% else %}
-            <td>{{ panelist_info.score }}</td>
-            {% endif %}
+            <td>{{ "{:f}".format(panelist_info.score_decimal.normalize()) if use_decimal_scores else panelist_info_score }}</td>
             <td>{{ rank_map[panelist_info.rank] }}</td>
         </tr>
         {% endfor %}

--- a/app/panelists/templates/panelists/gender-stats.html
+++ b/app/panelists/templates/panelists/gender-stats.html
@@ -71,45 +71,25 @@
         <tr>
             <td>{{ year }}</td>
             {% if gender_stats[year]["M"] %}
-                {% if use_decimal_scores %}
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["minimum"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["maximum"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["mean"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["median"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["standard_deviation"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["count"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["M"]["total"].normalize()) }}</td>
-                {% else %}
-            <td>{{ gender_stats[year]["M"]["minimum"] }}</td>
-            <td>{{ gender_stats[year]["M"]["maximum"] }}</td>
-            <td>{{ gender_stats[year]["M"]["mean"] }}</td>
-            <td>{{ gender_stats[year]["M"]["median"] }}</td>
-            <td>{{ gender_stats[year]["M"]["standard_deviation"] }}</td>
-            <td>{{ gender_stats[year]["M"]["count"] }}</td>
-            <td>{{ gender_stats[year]["M"]["total"] }}</td>
-                {% endif %}
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["minimum"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["minimum"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["maximum"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["maximum"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["mean"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["mean"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["median"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["median"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["standard_deviation"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["standard_deviation"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["count"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["count"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["M"]["total"].normalize()) if use_decimal_scores else gender_stats[year]["M"]["total"] }}</td>
             {% else %}
             <td class="no-data" colspan="7">-</td>
             {% endif %}
 
             {% if gender_stats[year]["F"] %}
-            {% if use_decimal_scores %}
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["minimum"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["maximum"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["mean"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["median"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["standard_deviation"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["count"].normalize()) }}</td>
-            <td>{{ "{:f}".format(gender_stats[year]["F"]["total"].normalize()) }}</td>
-                {% else %}
-            <td>{{ gender_stats[year]["F"]["minimum"] }}</td>
-            <td>{{ gender_stats[year]["F"]["maximum"] }}</td>
-            <td>{{ gender_stats[year]["F"]["mean"] }}</td>
-            <td>{{ gender_stats[year]["F"]["median"] }}</td>
-            <td>{{ gender_stats[year]["F"]["standard_deviation"] }}</td>
-            <td>{{ gender_stats[year]["F"]["count"] }}</td>
-            <td>{{ gender_stats[year]["F"]["total"] }}</td>
-                {% endif %}
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["minimum"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["minimum"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["maximum"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["maximum"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["mean"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["mean"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["median"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["median"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["standard_deviation"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["standard_deviation"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["count"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["count"] }}</td>
+            <td>{{ "{:f}".format(gender_stats[year]["F"]["total"].normalize()) if use_decimal_scores else gender_stats[year]["F"]["total"] }}</td>
             {% else %}
             <td class="no-data" colspan="7">-</td>
             {% endif %}

--- a/app/panelists/templates/panelists/perfect-scores.html
+++ b/app/panelists/templates/panelists/perfect-scores.html
@@ -23,7 +23,7 @@
 <!-- Start Report Section -->
 <table class="pure-table pure-table-bordered">
     <colgroup>
-        <col class="name panelist">
+        <col class="name panelist block-end">
         <col class="count">
         <col class="count">
     </colgroup>

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -172,7 +172,10 @@ def lightning_round_starting_ending_three_way_tie():
 def lightning_round_starting_three_way_tie():
     """View: Lightning Round Starting with a Three-Way Tie Report"""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
-    _shows = shows_starting_with_three_way_tie(database_connection=_database_connection)
+    _shows = shows_starting_with_three_way_tie(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     _database_connection.close()
 
     return render_template(

--- a/app/shows/templates/shows/all-women-panel.html
+++ b/app/shows/templates/shows/all-women-panel.html
@@ -59,11 +59,7 @@
                     <li>
                     {% if panelist.score %}
                     {{ panelist.name }}:
-                        {% if use_decimal_scores %}
-                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
-                        {% else %}
-                    {{ panelist.score }}
-                        {% endif %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) if use_decimal_scores else panelist.score }}
                     {% else %}
                     {{ panelist.name }}
                     {% endif %}

--- a/app/shows/templates/shows/high-scoring.html
+++ b/app/shows/templates/shows/high-scoring.html
@@ -68,11 +68,7 @@
                 <ul class="no-bullets">
                 {% for panelist in show.panelists %}
                     <li>{{ panelist.name }}:
-                    {% if use_decimal_scores %}
-                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
-                    {% else %}
-                    {{ panelist.score }}
-                    {% endif %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) if use_decimal_scores else panelist.score }}
                     </li>
                 {% endfor %}
                 </ul>

--- a/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
+++ b/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
@@ -43,11 +43,7 @@
                 {{ shows[show][0]["panelist"] }}
             </td>
             <td>
-                {% if use_decimal_scores %}
-                {{ "{:f}".format(shows[show][0]["score_decimal"].normalize()) }}
-                {% else %}
-                {{ shows[show][0]["score"] }}
-                {% endif %}
+                {{ "{:f}".format(shows[show][0]["score_decimal"].normalize()) if use_decimal_scores else shows[show][0]["score"] }}
             </td>
             <td>
                 {{ rank_map[shows[show][0]["rank"]] }}

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -45,11 +45,7 @@
                 </ul>
             </td>
             <td>
-            {% if use_decimal_scores %}
-            {{ "{:f}".format(show.score_decimal.normalize()) }}
-            {% else %}
-            {{ show.score }}
-            {% endif %}
+            {{ "{:f}".format(show.score_decimal.normalize()) if use_decimal_scores else show.score }}
             </td>
         </tr>
         {% endfor %}

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -49,14 +49,10 @@
                 {% endfor %}
                 </ul>
             </td>
-            <td>{{ show.start }}</td>
-            <td>{{ show.correct }}</td>
+            <td>{{ "{:f}".format(show.start_decimal.normalize()) if use_decimal_scores else show.start }}</td>
+            <td>{{ "{:f}".format(show.correct_decimal.normalize()) if use_decimal_scores else show.correct }}</td>
             <td>
-            {% if use_decimal_scores %}
-            {{ "{:f}".format(show.score_decimal.normalize()) }}
-            {% else %}
-            {{ show.score }}
-            {% endif %}
+            {{ "{:f}".format(show.score_decimal.normalize()) if use_decimal_scores else show.score }}
             </td>
         </tr>
         {% endfor %}

--- a/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
@@ -48,7 +48,7 @@
                 {% endfor %}
                 </ul>
             </td>
-            <td>{{ show.score }}</td>
+            <td>{{ "{:f}".format(show.score.normalize()) if use_decimal_scores else show.score }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/app/shows/templates/shows/lightning-round-starting-zero-points.html
+++ b/app/shows/templates/shows/lightning-round-starting-zero-points.html
@@ -47,11 +47,7 @@
             <td>{{ show.panelist.start }}</td>
             <td>{{ show.panelist.correct }}</td>
             <td>
-            {% if use_decimal_scores %}
-            {{ "{:f}".format(show.panelist.score_decimal.normalize()) }}
-            {% else %}
-            {{ show.panelist.score }}
-            {% endif %}
+            {{ "{:f}".format(show.panelist.score_decimal.normalize()) if use_decimal_scores else show.panelist.score }}
             </td>
             <td>{{ rank_map[show.panelist.rank] }}</td>
         </tr>

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -47,11 +47,7 @@
             <td>{{ show.panelist.start }}</td>
             <td>{{ show.panelist.correct }}</td>
             <td>
-            {% if use_decimal_scores %}
-            {{ "{:f}".format(show.panelist.score_decimal.normalize()) }}
-            {% else %}
-            {{ show.panelist.score }}
-            {% endif %}
+            {{ "{:f}".format(show.panelist.score_decimal.normalize()) if use_decimal_scores else show.panelist.score }}
             </td>
             <td>{{ rank_map[show.panelist.rank] }}</td>
         </tr>

--- a/app/shows/templates/shows/low-scoring.html
+++ b/app/shows/templates/shows/low-scoring.html
@@ -71,11 +71,7 @@
                 <ul class="no-bullets">
                 {% for panelist in show.panelists %}
                     <li>{{ panelist.name }}:
-                    {% if use_decimal_scores %}
-                    {{ "{:f}".format(panelist.score_decimal.normalize()) }}
-                    {% else %}
-                    {{ panelist.score }}
-                    {% endif %}
+                    {{ "{:f}".format(panelist.score_decimal.normalize()) if use_decimal_scores else panelist.score }}
                     </li>
                 {% endfor %}
                 </ul>

--- a/app/shows/templates/shows/perfect-panelist-scores.html
+++ b/app/shows/templates/shows/perfect-panelist-scores.html
@@ -48,17 +48,9 @@
             <td><a href="{{ stats_url }}/shows/{{ show.date|replace('-', '/') }}">{{ show.date }}</a></td>
             <td>{{ show.panelist }}</td>
             {% if show.score > 20 %}
-                {% if use_decimal_scores %}
-            <td><b>{{ "{:f}".format(show.score_decimal.normalize()) }}</b></td>
-                {% else %}
-            <td><b>{{ show.score }}</b></td>
-                {% endif %}
+            <td><b>{{ "{:f}".format(show.score_decimal.normalize()) if use_decimal_scores else show.score }}</b></td>
             {% else %}
-            {% if use_decimal_scores %}
-            <td>{{ "{:f}".format(show.score_decimal.normalize()) }}</td>
-            {% else %}
-            <td>{{ show.score }}</td>
-            {% endif %}
+            <td>{{ "{:f}".format(show.score_decimal.normalize()) if use_decimal_scores else show.score }}</td>
             {% endif %}
         </tr>
         {% endfor %}

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.4.0"
+APP_VERSION = "2.5.0"


### PR DESCRIPTION
## Application Changes

- Add support for the new decimal panelist Lightning Fill-in-the-Blank start and correct columns, `panelistlrndstart_decimal` and `panelistlrndcorrect_decimal`, respectively
- Optimize some of the template checks for `use_decimal_scores`