### PR TITLE
Upgrade to Flask 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.6.0
+
+### Component Changes
+
+- Upgrade Flask from 2.3.2 to 3.0.0
+- Upgrade gunicorn from 20.1.0 to 21.2.0
+- Upgrade pytz from 2023.3 to 2023.3.post1
+
+### Development Changes
+
+- Upgrade pycodestyle from 2.11.0 to 2.11.1
+- Upgrade pytest from 7.4.0 to 7.4.3
+- Upgrade black from 23.7.0 to 23.10.1
+
 ## 2.5.0
 
 ### Application Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.5.0"
+APP_VERSION = "2.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.black]
-required-version = "23.7.0"
-target-version = ["py38", "py39", "py310", "py311"]
+required-version = "23.10.1"
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 flake8==6.1.0
-pycodestyle==2.11.0
-pytest==7.4.0
-black==23.7.0
+pycodestyle==2.11.1
+pytest==7.4.3
+black==23.10.1
 
-Flask==2.3.2
-gunicorn==20.1.0
+Flask==3.0.0
+gunicorn==21.2.0
 Markdown==3.4.3
 mysql-connector-python==8.0.33
 numpy==1.24.3
 python-dateutil==2.8.2
-pytz==2023.3
+pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Flask==2.3.2
-gunicorn==20.1.0
+Flask==3.0.0
+gunicorn==21.2.0
 Markdown==3.4.3
 mysql-connector-python==8.0.33
 numpy==1.24.3
 python-dateutil==2.8.2
-pytz==2023.3
+pytz==2023.3.post1


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 2.3.2 to 3.0.0
- Upgrade gunicorn from 20.1.0 to 21.2.0
- Upgrade pytz from 2023.3 to 2023.3.post1

## Development Changes

- Upgrade pycodestyle from 2.11.0 to 2.11.1
- Upgrade pytest from 7.4.0 to 7.4.3
- Upgrade black from 23.7.0 to 23.10.1