### PR TITLE
Correct description for Low Scoring Shows report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.6.2
+
+### Application Changes
+
+- Correct wording for the Low Scoring Shows report description to reflect that the report only includes shows with a panelist total score of less than 30 points
+
 ## 2.6.1
 
 ### Application Changes

--- a/app/shows/templates/shows/_reports.html
+++ b/app/shows/templates/shows/_reports.html
@@ -83,8 +83,8 @@
         <a href="{{ url_for('shows.low_scoring') }}">Low Scoring Shows</a>
     </dt>
     <dd>
-        This report provides a list of show locations and the corresponding
-        average panelist score and average total score, in descending order.
+        This report provides a list of shows in which the total score for all
+        three panelists is less than or equal to 30, listed in ascending order.
     </dd>
     <dd>
         One exception from the scoring is that the 25th Anniversary Special, that

--- a/app/shows/templates/shows/low-scoring.html
+++ b/app/shows/templates/shows/low-scoring.html
@@ -14,7 +14,7 @@
 <h2>Low Scoring Shows</h2>
 <p>
     This report provides a list of shows in which the total score for all
-    three panelists is less than or equal to 30, listed in ascending order.
+    three panelists is less than 30, listed in ascending order.
 </p>
 <p>
     The list excludes the 20th Anniversary show due to the unique

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.6.1"
+APP_VERSION = "2.6.2"


### PR DESCRIPTION
## Application Changes

- Correct wording for the Low Scoring Shows report description to reflect that the report only includes shows with a panelist total score of less than 30 points