### PR TITLE
Support Python 3.12, Drop Python < 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 2.7.0
+
+**Starting with version 2.7.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+### Application Changes
+
+- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`
+
+### Component Changes
+
+- Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+- Upgrade numpy from 1.24.3 to 1.26.0
+- Remove python-dateutil from dependencies
+
+### Development Changes
+
+- Upgrade black from 23.10.1 to 23.11.0
+- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
+
 ## 2.6.2
 
 ### Application Changes

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,7 +1,7 @@
 # INSTALLING
 
 The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses
-`systemd` to manage services. Python 3.8 or newer is required and the system must already have a working installation available.
+`systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
 
 This document provides instructions on how to serve the application through [Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a front-end HTTP server. Other options are available for serving up applications built using Flask, but those options will not be covered here.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flask-based web application that serves up a collection of reports based on coll
 
 ## Requirements
 
-- Python 3.8 or newer
+- Python 3.10 or newer
 - MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Installation

--- a/app/utility.py
+++ b/app/utility.py
@@ -6,12 +6,10 @@
 """Utility functions used by the Wait Wait Reports"""
 
 from datetime import datetime
-from decimal import Decimal
 from functools import cmp_to_key
 import json
 from typing import Dict, List
 
-from dateutil import parser
 from flask import current_app
 import markdown
 from mysql.connector import connect, DatabaseError
@@ -60,7 +58,7 @@ def date_string_to_date(**kwargs):
     """Used to convert an ISO-style date string into a datetime object"""
     if "date_string" in kwargs and kwargs["date_string"]:
         try:
-            date_object = parser.parse(kwargs["date_string"])
+            date_object = datetime.datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
             return date_object
 
         except ValueError:

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 """Version module for Wait Wait Reports"""
 
-APP_VERSION = "2.6.2"
+APP_VERSION = "2.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-required-version = "23.10.1"
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
 minversion = "7.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
 flake8==6.1.0
 pycodestyle==2.11.1
 pytest==7.4.3
-black==23.10.1
+black==23.11.0
 
 Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.4.3
-mysql-connector-python==8.0.33
-numpy==1.24.3
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.4.3
-mysql-connector-python==8.0.33
-numpy==1.24.3
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 pytz==2023.3.post1


### PR DESCRIPTION
## Application Changes

- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`

## Component Changes

- Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
- Upgrade numpy from 1.24.3 to 1.26.0
- Remove python-dateutil from dependencies

## Development Changes

- Upgrade black from 23.10.1 to 23.11.0
- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`