### PR TITLE
Code cleanup, linting/formatting, sponsor links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add type hints for a majority of the return types for routes and utility modules
 - Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604
 - Change handling of `time_zone` configuration value to prevent use of `pytz.timezone()` in function arguments
+- Add support for project sponsorship links to Patreon and GitHub via `settings.patreon_url` and `settings.github_sponsors_url` config keys
 
 ### Component Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 2.9.0
+
+### Application Changes
+
+- Add type hints for a majority of the return types for routes and utility modules
+- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604
+- Change handling of `time_zone` configuration value to prevent use of `pytz.timezone()` in function arguments
+
+### Component Changes
+
+- Upgrade Markdown from 3.5.1 to 3.5.2
+- Upgrade numpy from 1.26.0 to 1.26.3
+
+### Development Changes
+
+- Switch to Ruff for code linting and formatting (with the help of Black)
+- Upgrade pytest from 7.4.3 to 7.4.4
+- Upgrade black from 23.11.0 to 23.12.1
+
 ## 2.8.0
 
 ### Application Changes

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,7 +1,6 @@
 # INSTALLING
 
-The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses
-`systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
+The following instructions target Ubuntu 22.04 LTS and Debian 12; but, with some minor changes, should also apply to Linux distribution that uses `systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
 
 This document provides instructions on how to serve the application through [Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a front-end HTTP server. Other options are available for serving up applications built using Flask, but those options will not be covered here.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -67,6 +67,7 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
     app.jinja_env.globals["use_decimal_scores"] = _config["settings"][
         "use_decimal_scores"
     ]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -68,6 +68,9 @@ def create_app():
         "mastodon_user", ""
     )
     app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
+    app.jinja_env.globals["github_sponsor_url"] = _config["settings"].get(
+        "github_sponsor_url", ""
+    )
     app.jinja_env.globals["use_decimal_scores"] = _config["settings"][
         "use_decimal_scores"
     ]

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,7 +6,7 @@
 """Shared Dictionaries for Wait Wait Reports."""
 
 
-RANK_MAP = {
+RANK_MAP: dict[str, str] = {
     "1": "First",
     "1t": "First Tied",
     "2": "Second",

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -1,17 +1,19 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Error Handlers Module for Wait Wait Reports."""
+from typing import Literal
+
 from flask import render_template
 
 
-def not_found(error):
+def not_found(error) -> tuple[str, Literal[404]]:
     """Handle resource not found conditions."""
     return render_template("errors/404.html", error_description=error.description), 404
 
 
-def handle_exception(error):
+def handle_exception(error) -> tuple[str, Literal[500]]:
     """Handle exceptions in a slightly more graceful manner."""
     return render_template("errors/500.html"), 500

--- a/app/guests/__init__.py
+++ b/app/guests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/guests/redirects.py
+++ b/app/guests/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Guests Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,30 +13,30 @@ blueprint = Blueprint("guests_redirects", __name__)
 
 @blueprint.route("/guest")
 @blueprint.route("/guests")
-def index():
+def index() -> Response:
     """View: Guest Index."""
     return redirect_url(url_for("guests.index"), status_code=301)
 
 
 @blueprint.route("/guest/best_of_only")
-def best_of_only():
+def best_of_only() -> Response:
     """View: Guests Best Of Only Report Redirect."""
     return redirect_url(url_for("guests.best_of_only"), status_code=301)
 
 
 @blueprint.route("/guest/most_appearances")
-def most_appearances():
+def most_appearances() -> Response:
     """View: Guests Most Appearances Report."""
     return redirect_url(url_for("guests.most_appearances"), status_code=301)
 
 
 @blueprint.route("/guest/scoring_exceptions")
-def scoring_exceptions():
+def scoring_exceptions() -> Response:
     """View: Guests Scoring Exceptions Report."""
     return redirect_url(url_for("guests.scoring_exceptions"), status_code=301)
 
 
 @blueprint.route("/guest/three_pointers")
-def three_pointers():
+def three_pointers() -> Response:
     """View: Guests Three Pointers Report."""
     return redirect_url(url_for("guests.three_pointers"), status_code=301)

--- a/app/guests/reports/__init__.py
+++ b/app/guests/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/guests/reports/best_of_only.py
+++ b/app/guests/reports/best_of_only.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Guest Best Of Only Appearances Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_guest_appearances(
-    guest_id: int, database_connection: mysql.connector.connect
+    guest_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict]:
     """Retrieve a list of shows a Not My Job guest has made an appearance on (including Best Of and Repeats)."""
     if not database_connection.is_connected():
@@ -48,7 +49,7 @@ def retrieve_guest_appearances(
 
 
 def retrieve_best_of_only_guests(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieves a list of Not My Job guests that have only appeared on Best Of shows."""
     if not database_connection.is_connected():

--- a/app/guests/reports/most_appearances.py
+++ b/app/guests/reports/most_appearances.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Guest Most Appearances Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from app.utility import multi_key_sort
 
 
 def retrieve_guest_most_appearances_all(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, dict]:
     """Returns a dictionary of all guests that have appeared on the show more than once.
 
@@ -53,7 +54,7 @@ def retrieve_guest_most_appearances_all(
 
 
 def retrieve_guest_most_appearances_regular(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, dict]:
     """Returns a dictionary of all guests that have appeared on the show more than once.
 
@@ -95,7 +96,7 @@ def retrieve_guest_most_appearances_regular(
 
 
 def guest_multiple_appearances(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Get a list of guests that have appeared on the show multiple times.
 

--- a/app/guests/reports/scores.py
+++ b/app/guests/reports/scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,12 @@
 """WWDTM Guest Scores Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_scoring_exceptions(
-    guest_id: int, database_connection: mysql.connector.connect
+    guest_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str, Any]]:
     """Retrieve a list of instances where a Not My Job guest has had a scoring exception."""
     if not database_connection.is_connected():
@@ -52,7 +53,7 @@ def retrieve_scoring_exceptions(
 
 
 def retrieve_guest_scores(
-    guest_id: int, database_connection: mysql.connector.connect
+    guest_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str, Any]]:
     """Retrieve a list of instances where a requested Not My Job guest has received three points."""
     if not database_connection.is_connected():
@@ -94,7 +95,7 @@ def retrieve_guest_scores(
 
 
 def retrieve_all_scoring_exceptions(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of all Not My Job scoring exceptions."""
     if not database_connection.is_connected():
@@ -135,7 +136,7 @@ def retrieve_all_scoring_exceptions(
 
 
 def retrieve_all_three_pointers(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieve a list instances where Not My Job guests have won.
 

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,13 +15,13 @@ blueprint = Blueprint("guests", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Guests Index."""
     return render_template("guests/_index.html")
 
 
 @blueprint.route("/best-of-only")
-def best_of_only():
+def best_of_only() -> str:
     """View: Guests Best Of Only Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _guests = retrieve_best_of_only_guests(database_connection=_database_connection)
@@ -30,7 +30,7 @@ def best_of_only():
 
 
 @blueprint.route("/most-appearances")
-def most_appearances():
+def most_appearances() -> str:
     """View: Guests Most Appearances Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _guests = guest_multiple_appearances(database_connection=_database_connection)
@@ -39,7 +39,7 @@ def most_appearances():
 
 
 @blueprint.route("/scoring-exceptions")
-def scoring_exceptions():
+def scoring_exceptions() -> str:
     """View: Guests Scoring Exceptions Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _exceptions = retrieve_all_scoring_exceptions(
@@ -50,7 +50,7 @@ def scoring_exceptions():
 
 
 @blueprint.route("/three-pointers")
-def three_pointers():
+def three_pointers() -> str:
     """View: Guests Three Pointers Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _three_pointers = retrieve_all_three_pointers(

--- a/app/hosts/__init__.py
+++ b/app/hosts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/hosts/redirects.py
+++ b/app/hosts/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Hosts Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,12 +13,12 @@ blueprint = Blueprint("hosts_redirects", __name__)
 
 @blueprint.route("/host")
 @blueprint.route("/hosts")
-def index():
+def index() -> Response:
     """View: Hosts Index Redirect."""
     return redirect_url(url_for("hosts.index"), status_code=301)
 
 
 @blueprint.route("/host/appearance_summary")
-def best_of_only():
+def best_of_only() -> Response:
     """View: Hosts Appearance Summary Report Redirect."""
     return redirect_url(url_for("hosts.appearance_summary"), status_code=301)

--- a/app/hosts/reports/__init__.py
+++ b/app/hosts/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/hosts/reports/appearances.py
+++ b/app/hosts/reports/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,12 @@
 """WWDTM Hosts Appearances Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_hosts(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, str]]:
     """Retrieves a dictionary for all available hosts from the database."""
     if not database_connection.is_connected():
@@ -43,7 +44,7 @@ def retrieve_hosts(
 
 
 def retrieve_appearances_by_host(
-    host_slug: str, database_connection: mysql.connector.connect
+    host_slug: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[str, int]:
     """Retrieve appearance data for the requested host."""
     if not database_connection.is_connected():
@@ -85,7 +86,7 @@ def retrieve_appearances_by_host(
 
 
 def retrieve_first_most_recent_appearances(
-    host_slug: str, database_connection: mysql.connector.connect
+    host_slug: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[str, str]:
     """Retrieve first and most recent appearances for both regular and all shows for a host."""
     if not database_connection.is_connected():
@@ -143,7 +144,7 @@ def retrieve_first_most_recent_appearances(
 
 
 def retrieve_appearance_summaries(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve host appearance summary.
 

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,13 +13,13 @@ blueprint = Blueprint("hosts", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Hosts Index."""
     return render_template("hosts/_index.html")
 
 
 @blueprint.route("/appearance-summary")
-def appearance_summary():
+def appearance_summary() -> str:
     """View: Hosts Appearance Summary Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     summary = retrieve_appearance_summaries(database_connection=_database_connection)

--- a/app/locations/__init__.py
+++ b/app/locations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/locations/redirects.py
+++ b/app/locations/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Locations Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,12 +13,12 @@ blueprint = Blueprint("locations_redirects", __name__)
 
 @blueprint.route("/location")
 @blueprint.route("/locations")
-def index():
+def index() -> Response:
     """View: Locations Index Redirect."""
     return redirect_url(url_for("locations.index"), status_code=301)
 
 
 @blueprint.route("/location/average_scores")
-def average_scores():
+def average_scores() -> Response:
     """View: Locations Average Scores Report Redirect."""
     return redirect_url(url_for("locations.average_scores"), status_code=301)

--- a/app/locations/reports/__init__.py
+++ b/app/locations/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/locations/reports/average_scores.py
+++ b/app/locations/reports/average_scores.py
@@ -1,19 +1,21 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Location Score Breakdown Report Functions."""
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_average_scores_by_location(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
-) -> List[Dict[str, Any]]:
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
+) -> list[dict[str, Any]]:
     """Retrieve average scores sorted by location."""
     if (
         use_decimal_scores

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -13,13 +13,13 @@ blueprint = Blueprint("locations", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Locations Index."""
     return render_template("locations/_index.html")
 
 
 @blueprint.route("/average-scores")
-def average_scores():
+def average_scores() -> str:
     """View: Locations Average Scores Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _locations = retrieve_average_scores_by_location(

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -12,6 +12,6 @@ blueprint = Blueprint("main_redirects", __name__)
 
 
 @blueprint.route("/favicon.ico")
-def favicon():
+def favicon() -> Response:
     """Redirect: /favicon.ico to /static/favicon.ico."""
     return redirect_url(url_for("static", filename="favicon.ico"), status_code=301)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,25 +1,24 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Routes for Wait Wait Reports."""
-from os.path import exists, join
 from pathlib import Path
 
-from flask import Blueprint, Response, current_app, render_template, send_file
+from flask import Blueprint, Response, render_template, send_file
 
 blueprint = Blueprint("main", __name__)
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Site Index Page."""
     return render_template("pages/_index.html")
 
 
 @blueprint.route("/robots.txt")
-def robots_txt():
+def robots_txt() -> Response:
     """View: robots.txt File."""
     static_robots = Path.cwd() / "app" / "static" / "robots.txt"
     if not static_robots.exists():

--- a/app/panelists/__init__.py
+++ b/app/panelists/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/panelists/redirects.py
+++ b/app/panelists/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Panelists Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,37 +13,37 @@ blueprint = Blueprint("panelists_redirects", __name__)
 
 @blueprint.route("/panelist")
 @blueprint.route("/panelists")
-def index():
+def index() -> Response:
     """View: Panelists Index Redirect."""
     return redirect_url(url_for("panelists.index"), status_code=301)
 
 
 @blueprint.route("/panelist/aggregate_scores")
-def aggregate_scores():
+def aggregate_scores() -> Response:
     """View: Panelists Aggregate Scores Report Redirect."""
     return redirect_url(url_for("panelists.aggregate_scores"), status_code=301)
 
 
 @blueprint.route("/panelist/appearances_by_year")
-def appearances_by_year():
+def appearances_by_year() -> Response:
     """View: Panelists Appearances By Year Report Redirect."""
     return redirect_url(url_for("panelists.appearances_by_year"), status_code=301)
 
 
 @blueprint.route("/panelist/bluff_stats")
-def bluff_stats():
+def bluff_stats() -> Response:
     """View: Panelists Bluff the Listener Statistics Report Redirect."""
     return redirect_url(url_for("panelists.bluff_stats"), status_code=301)
 
 
 @blueprint.route("/panelist/debut_by_year")
-def debut_by_year():
+def debut_by_year() -> Response:
     """View: Panelists Debut by Year Report Redirect."""
     return redirect_url(url_for("panelists.debut_by_year"), status_code=301)
 
 
 @blueprint.route("/panelist/first_most_recent_appearances")
-def first_most_recent_appearances():
+def first_most_recent_appearances() -> Response:
     """View: Panelists First and Most Recent Appearances Report Redirect."""
     return redirect_url(
         url_for("panelists.first_most_recent_appearances"), status_code=301
@@ -51,20 +51,20 @@ def first_most_recent_appearances():
 
 
 @blueprint.route("/panelist/gender_stats")
-def gender_stats():
+def gender_stats() -> Response:
     """View: Panelists Statistics by Gender Report Redirect."""
     return redirect_url(url_for("panelists.gender_stats"), status_code=301)
 
 
 @blueprint.route("/panelist/losing_streaks")
-def losing_streaks():
+def losing_streaks() -> Response:
     """View: Panelists Losing Streaks Report Redirect."""
     return redirect_url(url_for("panelists.losing_streaks"), status_code=301)
 
 
 @blueprint.route("/panelist/panel_gender_mix")
 @blueprint.route("/panelists/panel_gender_mix")
-def panel_gender_mix():
+def panel_gender_mix() -> Response:
     """View: Panel Gender Mix Report Redirect."""
     return redirect_url(url_for("shows.panel_gender_mix"), status_code=301)
 
@@ -72,36 +72,36 @@ def panel_gender_mix():
 @blueprint.route("/panelist/panelist_pvp_report")
 @blueprint.route("/panelist/panelist_vs_panelist")
 @blueprint.route("/panelist/pvp")
-def pvp():
+def pvp() -> Response:
     """View: Panelist vs Panelist Report Redirect."""
     return redirect_url(url_for("panelists.panelist_pvp"), status_code=301)
 
 
 @blueprint.route("/panelist/panelist_vs_panelist_scoring")
-def panelist_vs_panelist_scoring():
+def panelist_vs_panelist_scoring() -> Response:
     """View: Panelist vs Panelist Scoring Report Redirect."""
     return redirect_url(url_for("panelists.panelist_pvp_scoring"), status_code=301)
 
 
 @blueprint.route("/panelist/rankings_summary")
-def rankings_summary():
+def rankings_summary() -> Response:
     """View: Panelists Rankings Summary Report Redirect."""
     return redirect_url(url_for("panelists.rankings_summary"), status_code=301)
 
 
 @blueprint.route("/panelist/single_appearance")
-def single_appearance():
+def single_appearance() -> Response:
     """View: Panelists Single Appearance Report Redirect."""
     return redirect_url(url_for("panelists.single_appearance"), status_code=301)
 
 
 @blueprint.route("/panelist/stats_summary")
-def stats_summary():
+def stats_summary() -> Response:
     """View: Panelists Statistics Summary Report Redirect."""
     return redirect_url(url_for("panelists.stats_summary"), status_code=301)
 
 
 @blueprint.route("/panelist/win_streaks")
-def win_streaks():
+def win_streaks() -> Response:
     """View: Panelists Index Redirect."""
     return redirect_url(url_for("panelists.win_streaks"), status_code=301)

--- a/app/panelists/reports/__init__.py
+++ b/app/panelists/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/panelists/reports/aggregate_scores.py
+++ b/app/panelists/reports/aggregate_scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,13 +7,15 @@
 from decimal import Decimal
 from typing import Any
 
-import mysql.connector
 import numpy
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_all_scores(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[int | Decimal]:
     """Retrieve a list of all panelist scores from non-Best Of and non-Repeat shows."""
     if (
@@ -53,7 +55,8 @@ def retrieve_all_scores(
 
 
 def retrieve_score_spread(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict[str, int | Decimal]]:
     """Retrieve a list of grouped panelist scores from non-Best Of and non-Repeat shows."""
     if (

--- a/app/panelists/reports/appearances.py
+++ b/app/panelists/reports/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,13 +6,14 @@
 """WWDTM Panelist Appearances Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from . import common
 
 
 def retrieve_first_most_recent_appearances(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve first and most recent appearances for both regular and all shows for all panelists."""
     panelists = common.retrieve_panelists(database_connection=database_connection)

--- a/app/panelists/reports/appearances_by_year.py
+++ b/app/panelists/reports/appearances_by_year.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Appearances by Year Report Functions."""
-from typing import Any, Union
+from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_panelist_appearance_counts(
-    panelist_id: int, database_connection: mysql.connector.connect
+    panelist_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str | int, int]]:
     """Retrieve yearly appearance count for the requested panelist ID."""
     if not database_connection.is_connected():
@@ -45,7 +46,7 @@ def retrieve_panelist_appearance_counts(
 
 
 def retrieve_all_appearance_counts(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve all appearance counts for all panelists from the database."""
     if not database_connection.is_connected():
@@ -83,7 +84,9 @@ def retrieve_all_appearance_counts(
     return _panelists
 
 
-def retrieve_all_years(database_connection: mysql.connector.connect) -> list[int]:
+def retrieve_all_years(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[int]:
     """Retrieve a list of all available show years."""
     if not database_connection.is_connected():
         database_connection.reconnect()

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,14 @@
 """WWDTM Panelists Average Scores Report Functions."""
 from decimal import Decimal
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
-def empty_years_average(database_connection: mysql.connector.connect) -> dict[int, int]:
+def empty_years_average(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> dict[int, int]:
     """Retrieve a dictionary containing a list of available years as keys and zeroes for values."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -34,7 +37,7 @@ def empty_years_average(database_connection: mysql.connector.connect) -> dict[in
 
 def retrieve_panelist_yearly_average(
     panelist_slug: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict[str, str | list[float | Decimal]]:
     """Retrieves panelist name, slug string and average scores for each year."""
@@ -116,7 +119,8 @@ def retrieve_panelist_yearly_average(
 
 
 def retrieve_all_panelists_yearly_average(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieves a list of dictionaries for each panelist's yearly average scores."""
     if (

--- a/app/panelists/reports/bluff_stats.py
+++ b/app/panelists/reports/bluff_stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,15 @@
 """WWDTM Panelist Bluff the Listener Statistics Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from .common import retrieve_panelists
 
 
-def empty_years_bluff(database_connection: mysql.connector.connect) -> dict[int, int]:
+def empty_years_bluff(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> dict[int, int]:
     """Retrieve a dictionary containing a list of available years as keys and zeroes for values."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -42,7 +45,7 @@ def empty_years_bluff(database_connection: mysql.connector.connect) -> dict[int,
 
 
 def retrieve_panelist_bluff_counts(
-    panelist_id: int, database_connection: mysql.connector.connect
+    panelist_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[str, Any]:
     """Retrieves a dictionary containing Bluff the Listener counts for a panelist.
 
@@ -128,7 +131,7 @@ def retrieve_panelist_bluff_counts(
 
 
 def retrieve_all_panelist_bluff_stats(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieves a list of Bluff the Listener statistics for all panelists."""
     _panelists = retrieve_panelists(database_connection=database_connection)
@@ -149,8 +152,7 @@ def retrieve_all_panelist_bluff_stats(
 
 
 def retrieve_panelist_bluffs_by_year(
-    panelist_slug: str,
-    database_connection: mysql.connector.connect,
+    panelist_slug: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[int, int]:
     """Retrieve a panelist's Bluff the Listener statistics per year."""
     if not database_connection.is_connected():

--- a/app/panelists/reports/common.py
+++ b/app/panelists/reports/common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,12 @@
 """WWDTM Common Panelist Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_panelists(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieves a list of all available panelists from the database."""
     if not database_connection.is_connected():

--- a/app/panelists/reports/debut_by_year.py
+++ b/app/panelists/reports/debut_by_year.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,15 @@
 """WWDTM Panelist Debut by Year Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from .stats_summary import retrieve_appearances_by_panelist
 
 
-def retrieve_show_years(database_connection: mysql.connector.connect) -> list[int]:
+def retrieve_show_years(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[int]:
     """Retrieve a list of all show years."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -33,7 +36,7 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> list[in
 
 
 def retrieve_show_info(
-    show_date: str, database_connection: mysql.connector.connect
+    show_date: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[str, Any]:
     """Retrieve show host, scorekeeper and Not My Job guest for the requested show ID."""
     if not database_connection.is_connected():
@@ -65,7 +68,7 @@ def retrieve_show_info(
 
 
 def retrieve_show_guests(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[str]:
     """Retrieves a list of Not My Job guest(s) for the requested show ID."""
     if not database_connection.is_connected():
@@ -91,7 +94,7 @@ def retrieve_show_guests(
 
 
 def retrieve_panelists_first_shows(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Returns a dictionary containing all panelists and their first shows."""
     if not database_connection.is_connected():
@@ -144,7 +147,7 @@ def retrieve_panelists_first_shows(
 
 
 def panelist_debuts_by_year(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Returns a dictionary of show years with a list of panelists' debut information."""
     show_years = retrieve_show_years(database_connection=database_connection)

--- a/app/panelists/reports/first_appearance_wins.py
+++ b/app/panelists/reports/first_appearance_wins.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,14 @@
 """WWDTM Panelist First Appearance Wins."""
 from decimal import Decimal
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_panelists_first_appearance_wins(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict[str, str | int | Decimal]:
     """Returns a dictionary containing wins or tied for first for panelists' first appearance."""
     if (

--- a/app/panelists/reports/gender_stats.py
+++ b/app/panelists/reports/gender_stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,12 +7,15 @@
 from decimal import Decimal
 from typing import Any
 
-import mysql.connector
 import numpy
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
-def retrieve_show_years(database_connection: mysql.connector.connect) -> list[int]:
+def retrieve_show_years(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[int]:
     """Retrieve a list of available show years."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -36,7 +39,7 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> list[in
 def retrieve_scores_by_year_gender(
     year: int,
     gender: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> list[int | Decimal]:
     """Retrieve a list of panelist scores for a given year and panelists of the requested gender."""
@@ -88,7 +91,7 @@ def retrieve_scores_by_year_gender(
 
 
 def retrieve_stats_by_year_gender(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict[str, Any]:
     """Retrieve statistics about panelist scores broken out by year and gender."""

--- a/app/panelists/reports/panelist_vs_panelist.py
+++ b/app/panelists/reports/panelist_vs_panelist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,14 @@
 """WWDTM Panelist vs Panelist Report Functions."""
 from typing import Any
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_panelists(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict[str, Any]:
     """Retrieve panelists from the Stats Page database."""
     if (
@@ -59,7 +61,7 @@ def retrieve_panelists(
 
 def retrieve_panelist_appearances(
     panelists: dict[str, Any],
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict[str, str]:
     """Retrieve panelist appearances from the Stats Page database."""
@@ -110,7 +112,8 @@ def retrieve_panelist_appearances(
 
 
 def retrieve_show_scores(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict[str, Any]:
     """Retrieve scores for each show and panelist from the Stats Page Database."""
     if (

--- a/app/panelists/reports/panelist_vs_panelist_scoring.py
+++ b/app/panelists/reports/panelist_vs_panelist_scoring.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,14 +6,15 @@
 """WWDTM Panelist vs Panelist Scoring Report Functions."""
 from typing import Any
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_common_shows(
     panelist_slug_1: str,
     panelist_slug_2: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> list[int]:
     """Retrieve shows in which the two panelists have appeared together on a panel.
@@ -76,7 +77,7 @@ def retrieve_panelists_scores(
     show_ids: list[int],
     panelist_slug_a: str,
     panelist_slug_b: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict[str, Any]:
     """Retrieves panelists scores for the two requested panelists."""

--- a/app/panelists/reports/perfect_scores.py
+++ b/app/panelists/reports/perfect_scores.py
@@ -1,15 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Perfect Scores Report Functions."""
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_perfect_score_counts(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict[str, str | int]:
     """Returns a dictionary with counts of how many times panelists have scored a "perfect" score.
 

--- a/app/panelists/reports/rankings_summary.py
+++ b/app/panelists/reports/rankings_summary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,13 +6,14 @@
 """WWDTM Panelist Rankings Summary Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from . import common
 
 
 def retrieve_rankings_by_panelist(
-    panelist_id: int, database_connection: mysql.connector.connect
+    panelist_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict[str, Any]:
     """Retrieves ranking statistics for the requested panelist."""
     if not database_connection.is_connected():
@@ -93,7 +94,7 @@ def retrieve_rankings_by_panelist(
 
 
 def retrieve_all_panelist_rankings(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Returns ranking statistics for all available panelists."""
     panelists = common.retrieve_panelists(database_connection=database_connection)

--- a/app/panelists/reports/single_appearance.py
+++ b/app/panelists/reports/single_appearance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,14 @@
 """WWDTM Panelist Single Appearance Report Functions."""
 from typing import Any
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_single_appearances(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of panelists that have only made a single appearance on the show."""
     if (

--- a/app/panelists/reports/stats_summary.py
+++ b/app/panelists/reports/stats_summary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,16 +7,17 @@
 from decimal import Decimal
 from typing import Any
 
-import mysql.connector
 import numpy
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from . import common
 
 
 def retrieve_appearances_by_panelist(
     panelist_slug: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict[str, int]:
     """Retrieve appearance data for the requested panelist by the panelist's slug string."""
@@ -93,7 +94,7 @@ def retrieve_appearances_by_panelist(
 
 def retrieve_scores_by_panelist(
     panelist_slug: str,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> list[int]:
     """Retrieve all scores for the requested panelist by the panelist's slug string."""
@@ -136,7 +137,8 @@ def retrieve_scores_by_panelist(
 
 
 def retrieve_all_panelists_stats(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict[str, Any]:
     """Retrieve common statistics for all available panelists."""
     if (

--- a/app/panelists/reports/streaks.py
+++ b/app/panelists/reports/streaks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,13 @@
 """WWDTM Panelist Win/Loss Streaks Report Functions."""
 from typing import Any
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_panelists(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of panelists with their panelist ID and name."""
     if not database_connection.is_connected():
@@ -46,7 +47,7 @@ def retrieve_panelists(
 
 def retrieve_panelist_ranks(
     panelist_id: int,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of show dates and the panelist rank for the requested panelist ID."""
@@ -101,7 +102,8 @@ def retrieve_panelist_ranks(
 
 
 def calculate_panelist_losing_streaks(
-    panelists: list[dict[str, Any]], database_connection: mysql.connector.connect
+    panelists: list[dict[str, Any]],
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve panelist stats and calculate their losing streaks."""
     if not database_connection.is_connected():
@@ -177,7 +179,8 @@ def calculate_panelist_losing_streaks(
 
 
 def calculate_panelist_win_streaks(
-    panelists: list[dict[str, Any]], database_connection: mysql.connector.connect
+    panelists: list[dict[str, Any]],
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve panelist stats and calculate their win streaks."""
     win_streaks = []

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -58,13 +58,13 @@ blueprint = Blueprint("panelists", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Panelists Index."""
     return render_template("panelists/_index.html")
 
 
 @blueprint.route("/aggregate-scores")
-def aggregate_scores():
+def aggregate_scores() -> str:
     """View: Panelists Aggregate Scores Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _scores = retrieve_all_scores(
@@ -86,7 +86,7 @@ def aggregate_scores():
 
 
 @blueprint.route("/appearances-by-year")
-def appearances_by_year():
+def appearances_by_year() -> str:
     """View: Panelists Appearances by Year Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_all_appearance_counts(
@@ -102,7 +102,7 @@ def appearances_by_year():
 
 
 @blueprint.route("/average-scores-by-year", methods=["GET", "POST"])
-def average_scores_by_year():
+def average_scores_by_year() -> str:
     """View: Average Scores by Year Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists_list = pvp_retrieve_panelists(database_connection=_database_connection)
@@ -149,7 +149,7 @@ def average_scores_by_year():
 
 
 @blueprint.route("/average-scores-by-year-all")
-def average_scores_by_year_all():
+def average_scores_by_year_all() -> str:
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     average_scores = retrieve_all_panelists_yearly_average(
         database_connection=_database_connection,
@@ -167,7 +167,7 @@ def average_scores_by_year_all():
 
 
 @blueprint.route("/bluff-stats")
-def bluff_stats():
+def bluff_stats() -> str:
     """View: Panelists Bluff the Listener Statistics Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_all_panelist_bluff_stats(
@@ -178,7 +178,7 @@ def bluff_stats():
 
 
 @blueprint.route("/bluff-stats-by-year", methods=["GET", "POST"])
-def bluff_stats_by_year():
+def bluff_stats_by_year() -> str:
     """View: Panelists Bluff the Listener Statistics by Year Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
@@ -224,7 +224,7 @@ def bluff_stats_by_year():
 
 
 @blueprint.route("/debut-by-year")
-def debut_by_year():
+def debut_by_year() -> str:
     """View: Panelists Debut by Year Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _years = retrieve_show_years(database_connection=_database_connection)
@@ -234,7 +234,7 @@ def debut_by_year():
 
 
 @blueprint.route("/first-appearance-wins")
-def first_appearance_wins():
+def first_appearance_wins() -> str:
     """View: Panelists with First Appearance Wins."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists_first_appearance_wins(
@@ -248,7 +248,7 @@ def first_appearance_wins():
 
 
 @blueprint.route("/first-most-recent-appearances")
-def first_most_recent_appearances():
+def first_most_recent_appearances() -> str:
     """View: Panelists First and Most Recent Appearances Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists_appearances = retrieve_first_most_recent_appearances(
@@ -262,7 +262,7 @@ def first_most_recent_appearances():
 
 
 @blueprint.route("/gender-stats")
-def gender_stats():
+def gender_stats() -> str:
     """View: Panelists Statistics by Gender Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _stats = retrieve_stats_by_year_gender(
@@ -274,7 +274,7 @@ def gender_stats():
 
 
 @blueprint.route("/losing-streaks")
-def losing_streaks():
+def losing_streaks() -> str:
     """View: Panelists Losing Streaks Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
@@ -286,7 +286,7 @@ def losing_streaks():
 
 
 @blueprint.route("/panelist-pvp", methods=["GET", "POST"])
-def panelist_pvp():
+def panelist_pvp() -> str:
     """View: Panelist vs Panelist Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists_list = pvp_retrieve_panelists(database_connection=_database_connection)
@@ -333,7 +333,7 @@ def panelist_pvp():
 
 
 @blueprint.route("/panelist-pvp/all")
-def panelist_pvp_all():
+def panelist_pvp_all() -> str:
     """View: Panelist vs Panelist Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = pvp_retrieve_panelists(database_connection=_database_connection)
@@ -356,7 +356,7 @@ def panelist_pvp_all():
 
 
 @blueprint.route("/panelist-vs-panelist-scoring", methods=["GET", "POST"])
-def panelist_pvp_scoring():
+def panelist_pvp_scoring() -> str:
     """View: Panelist vs Panelist Scoring Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
@@ -425,7 +425,7 @@ def panelist_pvp_scoring():
 
 
 @blueprint.route("/perfect-scores")
-def perfect_scores():
+def perfect_scores() -> str:
     """View: Perfect Scores Count Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _counts = retrieve_perfect_score_counts(
@@ -437,7 +437,7 @@ def perfect_scores():
 
 
 @blueprint.route("/rankings-summary")
-def rankings_summary():
+def rankings_summary() -> str:
     """View: Panelists Rankings Summary Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
@@ -452,7 +452,7 @@ def rankings_summary():
 
 
 @blueprint.route("/single-appearance")
-def single_appearance():
+def single_appearance() -> str:
     """View: Panelists Single Appearance Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_single_appearances(
@@ -467,7 +467,7 @@ def single_appearance():
 
 
 @blueprint.route("/stats-summary")
-def stats_summary():
+def stats_summary() -> str:
     """View: Panelists Statistics Summary Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)
@@ -485,7 +485,7 @@ def stats_summary():
 
 
 @blueprint.route("/win-streaks")
-def win_streaks():
+def win_streaks() -> str:
     """View: Panelists Win Streaks Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)

--- a/app/scorekeepers/__init__.py
+++ b/app/scorekeepers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/scorekeepers/redirects.py
+++ b/app/scorekeepers/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Scorekeepers Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,18 +13,18 @@ blueprint = Blueprint("scorekeepers_redirects", __name__)
 
 @blueprint.route("/scorekeeper")
 @blueprint.route("/scorekeepers")
-def index():
+def index() -> Response:
     """View: Scorekeepers Index Redirect."""
     return redirect_url(url_for("scorekeepers.index"), status_code=301)
 
 
 @blueprint.route("/scorekeeper/appearance_summary")
-def appearance_summary():
+def appearance_summary() -> Response:
     """View: Scorekeepers Appearance Summary Report Redirect."""
     return redirect_url(url_for("scorekeepers.appearance_summary"), status_code=301)
 
 
 @blueprint.route("/scorekeeper/introductions")
-def introductions():
+def introductions() -> Response:
     """View: Scorekeepers Introductions Report Redirect."""
     return redirect_url(url_for("scorekeepers.introductions"), status_code=301)

--- a/app/scorekeepers/reports/__init__.py
+++ b/app/scorekeepers/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/scorekeepers/reports/appearances.py
+++ b/app/scorekeepers/reports/appearances.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Scorekeeper Appearances Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_all_scorekeepers(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieves a dictionary for all available scorekeepers from the database."""
     if not database_connection.is_connected():
@@ -41,7 +42,7 @@ def retrieve_all_scorekeepers(
 
 
 def retrieve_appearances_by_scorekeeper(
-    scorekeeper_slug: str, database_connection: mysql.connector.connect
+    scorekeeper_slug: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict:
     """Retrieve appearance data for the requested scorekeeper."""
     if not database_connection.is_connected():
@@ -83,7 +84,7 @@ def retrieve_appearances_by_scorekeeper(
 
 
 def retrieve_first_most_recent_appearances(
-    scorekeeper_slug: str, database_connection: mysql.connector.connect
+    scorekeeper_slug: str, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> dict:
     """Retrieve a scorekeeper's first and most recent appearances for both regular and all shows."""
     if not database_connection.is_connected():
@@ -139,7 +140,7 @@ def retrieve_first_most_recent_appearances(
 
 
 def retrieve_appearance_summaries(
-    database_connection: mysql.connector.connection,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieve scorekeeper appearance summary.
 

--- a/app/scorekeepers/reports/introductions.py
+++ b/app/scorekeepers/reports/introductions.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Scorekeeper Introductions Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_scorekeepers_with_introductions(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieve a list of scorekeepers that have show introduction entries in the database."""
     if not database_connection.is_connected():
@@ -44,7 +45,7 @@ def retrieve_scorekeepers_with_introductions(
 
 
 def retrieve_all_scorekeeper_introductions(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
     """Retrieve all scorekeeper introductions from the database."""
     if not database_connection.is_connected():

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,13 +17,13 @@ blueprint = Blueprint("scorekeepers", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Scorekeepers Index."""
     return render_template("scorekeepers/_index.html")
 
 
 @blueprint.route("/appearance-summary")
-def appearance_summary():
+def appearance_summary() -> str:
     """View: Scorekeepers Appearance Summary Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _summaries = retrieve_appearance_summaries(database_connection=_database_connection)
@@ -33,7 +33,7 @@ def appearance_summary():
 
 
 @blueprint.route("/introductions")
-def introductions():
+def introductions() -> str:
     """View: Scorekeepers Introductions Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _scorekeepers = retrieve_scorekeepers_with_introductions(

--- a/app/shows/__init__.py
+++ b/app/shows/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/shows/redirects.py
+++ b/app/shows/redirects.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Shows Redirect Routes for Wait Wait Reports."""
-from flask import Blueprint, url_for
+from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url
 
@@ -13,33 +13,33 @@ blueprint = Blueprint("shows_redirects", __name__)
 
 @blueprint.route("/show")
 @blueprint.route("/shows")
-def index():
+def index() -> Response:
     """View: Shows Index Redirect."""
     return redirect_url(url_for("shows.index"), status_code=301)
 
 
 @blueprint.route("/show/all_shows")
-def all_shows():
+def all_shows() -> Response:
     """View: All Shows Report Redirect."""
     return redirect_url(url_for("shows.all_shows"), status_code=301)
 
 
 @blueprint.route("/show/all_shows/asc")
 @blueprint.route("/shows/all-shows/asc")
-def all_shows_asc():
+def all_shows_asc() -> Response:
     """View: All Shows (Sort Ascending) Report Redirect."""
     return redirect_url(url_for("shows.all_shows"), status_code=301)
 
 
 @blueprint.route("/show/all_shows/desc")
 @blueprint.route("/shows/all-shows/desc")
-def all_shows_desc():
+def all_shows_desc() -> Response:
     """View: All Shows (Sort Descending) Report Redirect."""
     return redirect_url(url_for("shows.all_shows", sort="desc"), status_code=301)
 
 
 @blueprint.route("/show/all_women_panel")
-def all_women_panel():
+def all_women_panel() -> Response:
     """View: All Women Panel Report Redirect."""
     return redirect_url(url_for("shows.all_women_panel"), status_code=301)
 
@@ -47,7 +47,7 @@ def all_women_panel():
 @blueprint.route("/show/guest_host")
 @blueprint.route("/show/guest_hosts")
 @blueprint.route("/shows/guest-hosts")
-def guest_host():
+def guest_host() -> Response:
     """View: Shows with a Guest Hosts Report Redirect."""
     return redirect_url(url_for("shows.guest_host"), status_code=301)
 
@@ -55,19 +55,19 @@ def guest_host():
 @blueprint.route("/show/guest_scorekeeper")
 @blueprint.route("/show/guest_scorekeepers")
 @blueprint.route("/shows/guest-scorekeepers")
-def guest_scorekeeper():
+def guest_scorekeeper() -> Response:
     """View: Shows with a Guest Scorekeeper Report Redirect."""
     return redirect_url(url_for("shows.guest_scorekeeper"), status_code=301)
 
 
 @blueprint.route("/show/high_scoring")
-def high_scoring():
+def high_scoring() -> Response:
     """View: High Scoring Shows Report Redirect."""
     return redirect_url(url_for("shows.high_scoring"), status_code=301)
 
 
 @blueprint.route("/show/high_score_equal_sum_other_scores")
-def highest_score_equals_sum_other_scores():
+def highest_score_equals_sum_other_scores() -> Response:
     """View: Highest Score Equals the Sum of Other Scores Report Redirect."""
     return redirect_url(
         url_for("shows.highest_score_equals_sum_other_scores"), status_code=301
@@ -75,7 +75,7 @@ def highest_score_equals_sum_other_scores():
 
 
 @blueprint.route("/show/lightning_round_end_three_way_tie")
-def lightning_round_end_three_way_tie():
+def lightning_round_end_three_way_tie() -> Response:
     """View: Lightning Round Ending in a Three-Way Tie Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_ending_three_way_tie"), status_code=301
@@ -83,7 +83,7 @@ def lightning_round_end_three_way_tie():
 
 
 @blueprint.route("/show/lightning_round_start_end_three_way_tie")
-def lightning_round_start_end_three_way_tie():
+def lightning_round_start_end_three_way_tie() -> Response:
     """View: Lightning Round Starting and Ending in a Three-Way Tie Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_starting_ending_three_way_tie"), status_code=301
@@ -91,7 +91,7 @@ def lightning_round_start_end_three_way_tie():
 
 
 @blueprint.route("/show/lighting_round_start_zero")
-def lightning_round_start_zero_points():
+def lightning_round_start_zero_points() -> Response:
     """View: Lightning Round Starting with Zero Points Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_starting_zero_points"), status_code=301
@@ -105,39 +105,39 @@ def lightning_round_zero_correct():
 
 
 @blueprint.route("/show/low_scoring")
-def low_scoring():
+def low_scoring() -> Response:
     """View: Low Scoring Shows Report Redirect."""
     return redirect_url(url_for("shows.low_scoring"), status_code=301)
 
 
 @blueprint.route("/show/original_shows")
-def original_shows():
+def original_shows() -> Response:
     """View: Original Shows Report Redirect."""
     return redirect_url(url_for("shows.original_shows"), status_code=301)
 
 
 @blueprint.route("/show/original_shows/asc")
 @blueprint.route("/shows/original-shows/asc")
-def original_shows_asc():
+def original_shows_asc() -> Response:
     """View: Original Shows (Sort Ascending) Report Redirect."""
     return redirect_url(url_for("shows.original_shows"), status_code=301)
 
 
 @blueprint.route("/show/original_shows/desc")
 @blueprint.route("/shows/original-shows/desc")
-def original_shows_desc():
+def original_shows_desc() -> Response:
     """View: Original Shows (Sort Descending) Report Redirect."""
     return redirect_url(url_for("shows.original_shows", sort="desc"), status_code=301)
 
 
 @blueprint.route("/show/panel_gender_mix")
-def panel_gender_mix():
+def panel_gender_mix() -> Response:
     """View: Panel Gender Mix Report Redirect."""
     return redirect_url(url_for("shows.panel_gender_mix"), status_code=301)
 
 
 @blueprint.route("/show/search_multiple_panelists", methods=["GET", "POST"])
-def search_multiple_panelists():
+def search_multiple_panelists() -> Response:
     """View: Search Shows by Multiple Panelists Report Redirect."""
     return redirect_url(url_for("shows.search_multiple_panelists"), status_code=301)
 
@@ -147,6 +147,6 @@ def search_multiple_panelists():
 @blueprint.route("/shows/counts_by_year")
 @blueprint.route("/shows/show_counts_by_year")
 @blueprint.route("/shows/show-counts-by-year")
-def counts_by_year():
+def counts_by_year() -> Response:
     """View: Show Counts by Year Report Redirect."""
     return redirect_url(url_for("shows.counts_by_year"), status_code=301)

--- a/app/shows/reports/__init__.py
+++ b/app/shows/reports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/shows/reports/all_women_panel.py
+++ b/app/shows/reports/all_women_panel.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM All Women Panel Report Functions."""
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_show_details(
     show_id: int,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict:
     """Retrieves host, scorekeeper, panelist, guest and location information for the requested show ID."""
@@ -121,7 +122,8 @@ def retrieve_show_details(
 
 
 def retrieve_shows_all_women_panel(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieves details from all shows that have had an all women panel."""
     if (

--- a/app/shows/reports/guest_host.py
+++ b/app/shows/reports/guest_host.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Guest Hosts Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from app.shows.reports import show_details
 
 
 def retrieve_shows_guest_host(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieve a list of shows with guest hosts."""
     if not database_connection.is_connected():

--- a/app/shows/reports/guest_scorekeeper.py
+++ b/app/shows/reports/guest_scorekeeper.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Guest Scorekeeper Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from app.shows.reports import show_details
 
 
 def retrieve_shows_guest_scorekeeper(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Retrieve a list of shows with guest scorekeepers."""
     if not database_connection.is_connected():

--- a/app/shows/reports/guests_vs_bluffs.py
+++ b/app/shows/reports/guests_vs_bluffs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,12 @@
 """WWDTM Show Not My Job Guest Wins Rate vs Bluff the Listener Wins Rate Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_not_my_job_stats(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Returns a dictionary containing Not My Job statistics.
 
@@ -150,7 +151,7 @@ def retrieve_not_my_job_stats(
 
 
 def retrieve_bluff_stats(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Retrieves a dictionary containing Bluff the Listener statistics.
 

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -1,15 +1,17 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Lightning Round Report Functions."""
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_all_lightning_round_start(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> dict:
     """Retrieve a dictionary of all Lightning Fill-in-the-Blank round starting scores."""
     if (
@@ -70,7 +72,7 @@ def retrieve_all_lightning_round_start(
 
 def retrieve_scoring_info_by_show_id(
     show_id: int,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict:
     """Return Lightning Fill-in-the-Blank round scoring information.
@@ -143,7 +145,8 @@ def retrieve_scoring_info_by_show_id(
 
 
 def retrieve_panelists_by_show_id(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
     """Returns a list of panelists for the requested show ID."""
     if not database_connection.is_connected():
@@ -179,7 +182,8 @@ def retrieve_panelists_by_show_id(
 
 
 def shows_with_lightning_round_start_zero(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Return shows in which panelists start the Lightning Fill-in-the-Blank round with zero points."""
     if (
@@ -270,7 +274,8 @@ def shows_with_lightning_round_start_zero(
 
 
 def shows_lightning_round_start_zero(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Return list of shows in which a panelist starts the Lightning Fill-in-the-Blank round with zero points."""
     if (
@@ -360,7 +365,8 @@ def shows_lightning_round_start_zero(
 
 
 def shows_lightning_round_zero_correct(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Return list of shows in which a panelist answers zero Lightning Fill-in-the-Blank round questions correct."""
     if (
@@ -451,7 +457,8 @@ def shows_lightning_round_zero_correct(
 
 
 def shows_starting_with_three_way_tie(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieve all shows in which all three panelists started the Lightning round in a three-way tie."""
     show_scores = retrieve_all_lightning_round_start(
@@ -479,7 +486,8 @@ def shows_starting_with_three_way_tie(
 
 
 def shows_ending_with_three_way_tie(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieve all shows in which all three panelists ended the Lightning round in a three-way tie."""
     if (
@@ -558,7 +566,8 @@ def shows_ending_with_three_way_tie(
 
 
 def shows_starting_ending_three_way_tie(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieve all shows in which all three panelists started and ended the Lightning round in a three-way tie."""
     if (

--- a/app/shows/reports/panel_gender_mix.py
+++ b/app/shows/reports/panel_gender_mix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,10 +6,13 @@
 """WWDTM Show Panel Gender Mix Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
-def retrieve_show_years(database_connection: mysql.connector.connect) -> list[int]:
+def retrieve_show_years(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[int]:
     """Retrieve a list of show years available in the database."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -30,7 +33,7 @@ def retrieve_show_years(database_connection: mysql.connector.connect) -> list[in
 
 
 def retrieve_panel_gender_count_by_year(
-    year: int, database_connection: mysql.connector.connect
+    year: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> int:
     """Get a count of shows for the requested year that has the requested number of panelists of a given gender."""
     if not database_connection.is_connected():
@@ -66,7 +69,7 @@ def retrieve_panel_gender_count_by_year(
 
 
 def panel_gender_mix_breakdown(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[str, Any]:
     """Return a dictionary of panel gender breakdown for all show years with count for each year."""
     show_years = retrieve_show_years(database_connection=database_connection)

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,13 +6,14 @@
 """WWDTM Show Scoring Reports Functions."""
 from decimal import Decimal
 
-import mysql.connector
 from flask import current_app
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_show_details(
     show_id: int,
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     use_decimal_scores: bool = False,
 ) -> dict:
     """Retrieves host, scorekeeper, panelist, guest and location information for the requested show ID."""
@@ -141,7 +142,8 @@ def retrieve_show_details(
 
 
 def retrieve_shows_all_high_scoring(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieves details from shows with a panelist total score greater than or equal to 50."""
     if (
@@ -201,7 +203,8 @@ def retrieve_shows_all_high_scoring(
 
 
 def retrieve_shows_all_low_scoring(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieves details from shows with a panelist total score of less than 30.
 
@@ -267,7 +270,8 @@ def retrieve_shows_all_low_scoring(
 
 
 def retrieve_shows_panelist_score_sum_match(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict]:
     """Retrieves shows where a panelist's first place score matches the sum of the scores of the other two panelists.
 
@@ -364,7 +368,8 @@ def retrieve_shows_panelist_score_sum_match(
 
 
 def retrieve_shows_panelist_perfect_scores(
-    database_connection: mysql.connector.connect, use_decimal_scores: bool = False
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    use_decimal_scores: bool = False,
 ) -> list[dict[str, str | int]]:
     if (
         use_decimal_scores

--- a/app/shows/reports/search_multiple_panelists.py
+++ b/app/shows/reports/search_multiple_panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,12 +6,15 @@
 """WWDTM Search Shows by Multiple Selected Panelists Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from . import show_details as details
 
 
-def retrieve_panelist_slugs(database_connection: mysql.connector.connect) -> list[str]:
+def retrieve_panelist_slugs(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[str]:
     """Returns a list of valid panelist slugs."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -32,7 +35,9 @@ def retrieve_panelist_slugs(database_connection: mysql.connector.connect) -> lis
     return [row.panelistslug for row in result]
 
 
-def retrieve_panelists(database_connection: mysql.connector.connect) -> dict[str, str]:
+def retrieve_panelists(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> dict[str, str]:
     """Returns a dictionary containing valid panelists."""
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -54,7 +59,7 @@ def retrieve_panelists(database_connection: mysql.connector.connect) -> dict[str
 
 
 def retrieve_details(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str, Any]]:
     """Retrieve show details for the requested show ID."""
     if not database_connection.is_connected():
@@ -102,7 +107,7 @@ def retrieve_details(
 
 
 def retrieve_matching_one(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     panelist_slug_1: str,
     include_best_of: bool = False,
     include_repeats: bool = False,
@@ -154,7 +159,7 @@ def retrieve_matching_one(
 
 
 def retrieve_matching_two(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     panelist_slug_1: str,
     panelist_slug_2: str,
     include_best_of: bool = False,
@@ -213,7 +218,7 @@ def retrieve_matching_two(
 
 
 def retrieve_matching_three(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
     panelist_slug_1: str,
     panelist_slug_2: str,
     panelist_slug_3: str,

--- a/app/shows/reports/show_counts.py
+++ b/app/shows/reports/show_counts.py
@@ -1,14 +1,15 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Counts Report Functions."""
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_show_counts_by_year(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict[int, int]:
     """Retrieve the number of Regular, Best Of, Repeat and Repeat/Best Of shows broken down by year."""
     if not database_connection.is_connected():

--- a/app/shows/reports/show_details.py
+++ b/app/shows/reports/show_details.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,11 +6,12 @@
 """WWDTM Show Details Report Functions."""
 from typing import Any
 
-import mysql.connector
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 
 def retrieve_show_guests(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str, str]]:
     """Retrieve the Not My Job guest for the requested show ID."""
     if not database_connection.is_connected():
@@ -44,7 +45,7 @@ def retrieve_show_guests(
 
 
 def retrieve_show_panelists(
-    show_id: int, database_connection: mysql.connector.connect
+    show_id: int, database_connection: MySQLConnection | PooledMySQLConnection
 ) -> list[dict[str, str]]:
     """Retrieve panelists for the requested show ID."""
     if not database_connection.is_connected():
@@ -79,7 +80,7 @@ def retrieve_show_panelists(
 
 
 def retrieve_all_shows(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of all shows and basic information.
 
@@ -142,7 +143,7 @@ def retrieve_all_shows(
 
 
 def retrieve_all_original_shows(
-    database_connection: mysql.connector.connect,
+    database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
     """Retrieve a list of all original shows and basic information.
 

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -41,13 +41,13 @@ blueprint = Blueprint("shows", __name__, template_folder="templates")
 
 
 @blueprint.route("/")
-def index():
+def index() -> str:
     """View: Shows Index."""
     return render_template("shows/_index.html")
 
 
 @blueprint.route("/all-shows")
-def all_shows():
+def all_shows() -> str:
     """View: All Shows Report."""
     _ascending = True
     _database_connection = mysql.connector.connect(**current_app.config["database"])
@@ -67,7 +67,7 @@ def all_shows():
 
 
 @blueprint.route("/all-women-panel")
-def all_women_panel():
+def all_women_panel() -> str:
     """View: All Women Panel Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_all_women_panel(
@@ -80,7 +80,7 @@ def all_women_panel():
 
 
 @blueprint.route("/counts-by-year")
-def counts_by_year():
+def counts_by_year() -> str:
     """View: Show Counts by Year Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _counts = retrieve_show_counts_by_year(database_connection=_database_connection)
@@ -90,7 +90,7 @@ def counts_by_year():
 
 
 @blueprint.route("/guest-host")
-def guest_host():
+def guest_host() -> str:
     """View: Shows with a Guest Host Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_guest_host(database_connection=_database_connection)
@@ -100,7 +100,7 @@ def guest_host():
 
 
 @blueprint.route("/guest-scorekeeper")
-def guest_scorekeeper():
+def guest_scorekeeper() -> str:
     """View: Shows with a Guest Scorekeeper Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_guest_scorekeeper(database_connection=_database_connection)
@@ -110,7 +110,7 @@ def guest_scorekeeper():
 
 
 @blueprint.route("/high-scoring")
-def high_scoring():
+def high_scoring() -> str:
     """View: High Scoring Shows Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_all_high_scoring(
@@ -123,7 +123,7 @@ def high_scoring():
 
 
 @blueprint.route("/highest-score-equals-sum-other-scores")
-def highest_score_equals_sum_other_scores():
+def highest_score_equals_sum_other_scores() -> str:
     """View: Highest Score Equals the Sum of Other Scores Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_panelist_score_sum_match(
@@ -138,7 +138,7 @@ def highest_score_equals_sum_other_scores():
 
 
 @blueprint.route("/lightning-round-ending-three-way-tie")
-def lightning_round_ending_three_way_tie():
+def lightning_round_ending_three_way_tie() -> str:
     """View: Lightning Round Ending in a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_ending_with_three_way_tie(
@@ -153,7 +153,7 @@ def lightning_round_ending_three_way_tie():
 
 
 @blueprint.route("/lightning-round-starting-ending-three-way-tie")
-def lightning_round_starting_ending_three_way_tie():
+def lightning_round_starting_ending_three_way_tie() -> str:
     """View: Lightning Round Starting and Ending in a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_starting_ending_three_way_tie(
@@ -168,7 +168,7 @@ def lightning_round_starting_ending_three_way_tie():
 
 
 @blueprint.route("/lightning-round-starting-three-way-tie")
-def lightning_round_starting_three_way_tie():
+def lightning_round_starting_three_way_tie() -> str:
     """View: Lightning Round Starting with a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_starting_with_three_way_tie(
@@ -183,7 +183,7 @@ def lightning_round_starting_three_way_tie():
 
 
 @blueprint.route("/lightning-round-starting-zero-points")
-def lightning_round_starting_zero_points():
+def lightning_round_starting_zero_points() -> str:
     """View: Lightning Round Starting with Zero Points Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_start_zero(
@@ -198,7 +198,7 @@ def lightning_round_starting_zero_points():
 
 
 @blueprint.route("/lightning-round-zero-correct")
-def lightning_round_zero_correct():
+def lightning_round_zero_correct() -> str:
     """View: Lightning Round with Zero Correct Answers Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_zero_correct(
@@ -211,7 +211,7 @@ def lightning_round_zero_correct():
 
 
 @blueprint.route("/low-scoring")
-def low_scoring():
+def low_scoring() -> str:
     """View: Low Scoring Shows Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_all_low_scoring(
@@ -224,7 +224,7 @@ def low_scoring():
 
 
 @blueprint.route("/not-my-job-vs-bluffs")
-def not_my_job_vs_bluffs():
+def not_my_job_vs_bluffs() -> str:
     """View: Not My Job Guests vs Bluff the Listener Win Ratios Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _guest_stats = retrieve_not_my_job_stats(database_connection=_database_connection)
@@ -239,7 +239,7 @@ def not_my_job_vs_bluffs():
 
 
 @blueprint.route("/original-shows")
-def original_shows():
+def original_shows() -> str:
     """View: Original Shows Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = details_all_original_shows(database_connection=_database_connection)
@@ -261,7 +261,7 @@ def original_shows():
 
 
 @blueprint.route("/panel-gender-mix")
-def panel_gender_mix():
+def panel_gender_mix() -> str:
     """View: Shows Panel Gender Mix Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _mix = panel_gender_mix_breakdown(database_connection=_database_connection)
@@ -271,7 +271,7 @@ def panel_gender_mix():
 
 
 @blueprint.route("/perfect-panelist-scores")
-def perfect_panelist_scores():
+def perfect_panelist_scores() -> str:
     """View: Shows with Perfect Panelist Scores Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = retrieve_shows_panelist_perfect_scores(
@@ -284,7 +284,7 @@ def perfect_panelist_scores():
 
 
 @blueprint.route("/search-multiple-panelists", methods=["GET", "POST"])
-def search_multiple_panelists():
+def search_multiple_panelists() -> str:
     """View: Search Shows by Multiple Panelists Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _panelists = retrieve_panelists(database_connection=_database_connection)

--- a/app/sitemaps/__init__.py
+++ b/app/sitemaps/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -10,49 +10,49 @@ blueprint = Blueprint("sitemaps", __name__, template_folder="templates")
 
 
 @blueprint.route("/sitemap.xml")
-def primary():
+def primary() -> Response:
     """View: Primary Sitemap XML."""
     sitemap = render_template("sitemaps/sitemap.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-guests.xml")
-def guests():
+def guests() -> Response:
     """View: Guests Sitemap XML."""
     sitemap = render_template("sitemaps/guests.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-hosts.xml")
-def hosts():
+def hosts() -> Response:
     """View: Hosts Sitemap XML."""
     sitemap = render_template("sitemaps/hosts.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-locations.xml")
-def locations():
+def locations() -> Response:
     """View: Locations Sitemap XML."""
     sitemap = render_template("sitemaps/locations.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-panelists.xml")
-def panelists():
+def panelists() -> Response:
     """View: Panelists Sitemap XML."""
     sitemap = render_template("sitemaps/panelists.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-scorekeepers.xml")
-def scorekeepers():
+def scorekeepers() -> Response:
     """View: Scorekeepers Sitemap XML."""
     sitemap = render_template("sitemaps/scorekeepers.xml")
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-shows.xml")
-def shows():
+def shows() -> Response:
     """View: Shows Sitemap XML."""
     sitemap = render_template("sitemaps/shows.xml")
     return Response(sitemap, mimetype="text/xml")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -53,6 +53,18 @@
         {% endif %}
         All rights reserved.
     </div>
+    {% if patreon_url or github_sponsor_url %}
+    <div id="sponsor">
+        Sponsor this project at:
+        {% if patreon_url and github_sponsor_url %}
+        <a href="{{ github_sponsor_url }}">GitHub</a> and <a href="{{ patreon_url }}">Patreon</a>.
+        {% elif patreon_url %}
+        <a href="{{ patreon_url }}">Patreon</a>.
+        {% elif github_sponsor_url %}
+        <a href="{{ github_sponsor_url }}">GitHub</a>.
+        {% endif %}
+    </div>
+    {% endif %}
     <div id="source">Source code for this project is available on <a href="{{ repo_url }}">GitHub</a>
     under <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>.</div>
 </footer>

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/version.py
+++ b/app/version.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "2.8.0"
+APP_VERSION = "2.9.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -23,6 +23,7 @@
         "time_zone": "UTC",
         "mastodon_url": "",
         "mastodon_user": "",
+        "patreon_url": "",
         "use_decimal_scores": false
     }
 }

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
-required-version = "23.11.0"
+required-version = "23.12.1"
 target-version = ["py310", "py311", "py312"]
+line-length = 88
 
 [tool.pytest.ini_options]
 minversion = "7.4"
@@ -58,7 +59,7 @@ ignore = [
     "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
     "S608",
 ]
-line-length = 120 # Must agree with Black
+line-length = 88 # Must agree with Black
 
 [tool.ruff.flake8-bugbear]
 extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]

--- a/reports.py
+++ b/reports.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-black==23.11.0
-ruff==0.1.3
-pytest==7.4.3
+black==23.12.1
+ruff==0.1.13
+pytest==7.4.4
 
 Flask==3.0.0
 gunicorn==21.2.0
-Markdown==3.5.1
+Markdown==3.5.2
 mysql-connector-python==8.2.0
-numpy==1.26.0
+numpy==1.26.3
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.0.0
 gunicorn==21.2.0
-Markdown==3.5.1
+Markdown==3.5.2
 mysql-connector-python==8.2.0
-numpy==1.26.0
+numpy==1.26.3
 pytz==2023.3.post1

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_guests_redirects.py
+++ b/tests/test_guests_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_hosts_redirects.py
+++ b/tests/test_hosts_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_locations_redirects.py
+++ b/tests/test_locations_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_panelists_redirects.py
+++ b/tests/test_panelists_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_scorekeepers_redirects.py
+++ b/tests/test_scorekeepers_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_shows_redirects.py
+++ b/tests/test_shows_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_sitemaps.py
+++ b/tests/test_sitemaps.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # reports.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## Application Changes

- Add type hints for a majority of the return types for routes and utility modules
- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604
- Change handling of `time_zone` configuration value to prevent use of `pytz.timezone()` in function arguments
- Add support for project sponsorship links to Patreon and GitHub via `settings.patreon_url` and `settings.github_sponsors_url` config keys

## Component Changes

- Upgrade Markdown from 3.5.1 to 3.5.2
- Upgrade numpy from 1.26.0 to 1.26.3

## Development Changes

- Switch to Ruff for code linting and formatting (with the help of Black)
- Upgrade pytest from 7.4.3 to 7.4.4
- Upgrade black from 23.11.0 to 23.12.1