### PR TITLE
Bump flask, gunicorn, ruff and pytest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.9.2
+
+### Component Changes
+
+- Upgrade flask from 3.0.0
+- Upgrade gunicorn from 21.2.0 to 22.0.0
+- Upgrade numpy from 1.26.3 to 1.26.4
+- Upgrade pytz from 2023.3.post1 to 2024.1
+
+### Development Changes
+
+- Upgrade ruff from 0.1.13 to 0.3.6
+- Upgrade pytest from 7.4.4 to 8.1.1
+
 ## 2.9.1
 
 ### Development Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -80,9 +80,9 @@ def create_app():
     app.jinja_env.filters["markdown"] = utility.md_to_html
 
     # Check to see if panelistscore_decimal column exists and set a flag
-    app.config["app_settings"][
-        "has_decimal_scores_column"
-    ] = utility.panelist_decimal_score_exists(database_settings=app.config["database"])
+    app.config["app_settings"]["has_decimal_scores_column"] = (
+        utility.panelist_decimal_score_exists(database_settings=app.config["database"])
+    )
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/panelists/reports/streaks.py
+++ b/app/panelists/reports/streaks.py
@@ -246,9 +246,9 @@ def calculate_panelist_win_streaks(
             panelist["longest_streak"] = longest_streak
             panelist["longest_streak_dates"] = longest_streak_show_dates
             panelist["longest_streak_with_draws"] = longest_streak_with_draws
-            panelist[
-                "longest_streak_with_draws_dates"
-            ] = longest_streak_show_dates_with_draws
+            panelist["longest_streak_with_draws_dates"] = (
+                longest_streak_show_dates_with_draws
+            )
             win_streaks.append(panelist)
 
     return win_streaks

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "2.9.1"
+APP_VERSION = "2.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,43 @@ line-length = 88
 minversion = "7.4"
 filterwarnings = ["ignore::DeprecationWarning:mysql.*:"]
 norecursedirs = [".git", "venv", "dist", ".eggs", "wwdtm.egg-info"]
-#collect_ignore = ["perf_test.py"]
 
 [tool.ruff]
+target-version = "py310"
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+line-length = 88 # Must agree with Black
+
+[tool.ruff.lint]
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -30,44 +64,13 @@ select = [
     "YTT", # flake8-2020
 ]
 
-exclude = [
-    "migrations",
-    "__pycache__",
-    "manage.py",
-    "settings.py",
-    "env",
-    ".env",
-    "venv",
-    ".venv",
-]
-
-ignore = [
-    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "D200",
-    "D401",
-    "E402",
-    "E501",
-    "F401",
-    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
-    "S608",
-]
-line-length = 88 # Must agree with Black
-
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
 
-[tool.ruff.pydocstyle]
-convention = "numpy"
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -82,5 +85,5 @@ convention = "numpy"
     "S106",   # possible hardcoded password.
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
+ruff==0.3.6
 black==24.3.0
-ruff==0.1.13
-pytest==7.4.4
+pytest==8.1.1
 
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 Markdown==3.5.2
 mysql-connector-python==8.2.0
-numpy==1.26.3
-pytz==2023.3.post1
+numpy==1.26.4
+pytz==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 Markdown==3.5.2
 mysql-connector-python==8.2.0
-numpy==1.26.3
-pytz==2023.3.post1
+numpy==1.26.4
+pytz==2024.1


### PR DESCRIPTION
## Component Changes

- Upgrade flask from 3.0.0
- Upgrade gunicorn from 21.2.0 to 22.0.0
- Upgrade numpy from 1.26.3 to 1.26.4
- Upgrade pytz from 2023.3.post1 to 2024.1

## Development Changes

- Upgrade ruff from 0.1.13 to 0.3.6
- Upgrade pytest from 7.4.4 to 8.1.1