### PR TITLE
Refactor Database Queries and Experimental Support for MariaDB

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
             "source.sortImports": "explicit",
         },
         "editor.defaultFormatter": "ms-python.black-formatter"
-    }
+    },
+    "pylint.args": [
+        "--disable=C0206"
+    ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,12 @@
 - Removed the unused `app/templates/core` directory and blank HTML files
 - Updated Panelist Debut by Year report to include a list of years as part of a side navigation that appears on medium-sized and larger screens (>= 768 px)
 
+### Development Changes
+
+- Upgrade ruff from 0.3.6 to 0.5.1
+- Upgrade black from 24.3.0 to 24.4.2
+- Upgrade pytest from 8.1.1 to 8.1.2
+
 ## 2.0.5
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.10.0
+
+### Application Changes
+
+- Change the database queries and application logic for the panelist "Perfect Score Counts" and "Single Appearance" reports to allow the application to experimentally support MariaDB 11.4.2
+
 ## 2.9.2
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Change the database queries and application logic for the panelist "Perfect Score Counts" and "Single Appearance" reports to allow the application to experimentally support MariaDB 11.4.2
 
+### Development Changes
+
+- Upgrade ruff from 0.3.6 to 0.5.1
+- Upgrade black from 24.3.0 to 24.4.2
+- Upgrade pytest from 8.1.1 to 8.1.2
+
 ## 2.9.2
 
 ### Component Changes
@@ -254,12 +260,6 @@
 
 - Removed the unused `app/templates/core` directory and blank HTML files
 - Updated Panelist Debut by Year report to include a list of years as part of a side navigation that appears on medium-sized and larger screens (>= 768 px)
-
-### Development Changes
-
-- Upgrade ruff from 0.3.6 to 0.5.1
-- Upgrade black from 24.3.0 to 24.4.2
-- Upgrade pytest from 8.1.1 to 8.1.2
 
 ## 2.0.5
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Flask-based web application that serves up a collection of reports based on coll
 
 **Note:** Experimental support for MariaDB Server is only available starting with version 2.10.0 of the application. Older versions of MariaDB Server are not supported.
 
+Also, due to potential incompatibilities with the divergence of MySQL and MariaDB, including the Python Connector libraries, support for MariaDB may not be feasible in the long term.
+
 ## Installation
 
 Refer to [INSTALLING.md](./INSTALLING.md) for information on how to set up an instance of this web application that can be served through NGINX and Gunicorn.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Flask-based web application that serves up a collection of reports based on coll
 ## Requirements
 
 - Python 3.10 or newer
-- MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
+- MySQL Server 8.0 or newer (or another MySQL Server distribution based on MySQL Server 8.0 or newer) or MariaDB Server 11.4.2 or newer *(Experimental)*
+
+**Note:** Experimental support for MariaDB Server is only available starting with version 2.10.0 of the application. Older versions of MariaDB Server are not supported.
 
 ## Installation
 

--- a/app/panelists/reports/appearances.py
+++ b/app/panelists/reports/appearances.py
@@ -15,7 +15,7 @@ from . import common
 def retrieve_first_most_recent_appearances(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict[str, Any]]:
-    """Retrieve first and most recent appearances for both regular and all shows for all panelists."""
+    """Retrieve first/most recent appearances for both regular and all shows for all panelists."""
     panelists = common.retrieve_panelists(database_connection=database_connection)
 
     if not panelists:

--- a/app/panelists/reports/common.py
+++ b/app/panelists/reports/common.py
@@ -42,3 +42,34 @@ def retrieve_panelists(
         )
 
     return _panelists
+
+
+def retrieve_panelists_id_key(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> dict[int, dict]:
+    """Retrieves a dictionary of all available panelists from the database."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT p.panelistid, p.panelist, p.panelistslug
+        FROM ww_panelists p
+        WHERE p.panelist <> '<Multiple>'
+        ORDER BY p.panelistslug ASC;
+        """
+    cursor = database_connection.cursor(named_tuple=True)
+    cursor.execute(query)
+    result = cursor.fetchall()
+    cursor.close()
+
+    if not result:
+        return None
+
+    _panelists = {}
+    for row in result:
+        _panelists[row.panelistid] = {
+            "name": row.panelist,
+            "slug": row.panelistslug,
+        }
+
+    return _panelists

--- a/app/panelists/templates/panelists/perfect-scores.html
+++ b/app/panelists/templates/panelists/perfect-scores.html
@@ -32,8 +32,8 @@
             <th scope="col" rowspan="2">Panelist</th>
             <th scope="col" colspan="2">Total Score Count</th>
         <tr>
-            <th scope="col">= 20</th>
-            <th scope="col">&#x2265; 20</th>
+            <th scope="col"> &#x2265; 20</th>
+            <th scope="col"> = 20</th>
         </tr>
     </thead>
     <tbody>
@@ -41,12 +41,12 @@
         <tr>
             <td><a href="{{ stats_url }}/panelists/{{ counts[panelist].slug }}">
                 {{ counts[panelist].name }}</a></td>
+            <td>{{ counts[panelist].more_perfect }}</td>
             {% if counts[panelist].perfect %}
             <td>{{ counts[panelist].perfect }}</td>
             {% else %}
             <td class="no-data">-</td>
             {% endif %}
-            <td>{{ counts[panelist].more_perfect }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "2.9.2"
+APP_VERSION = "2.10.0"

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ from app import create_app
 
 @pytest.fixture
 def client():
+    """Pytest Client Fixture."""
     app: Flask = create_app()
-    with app.test_client() as client:
-        yield client
+    with app.test_client() as _client:
+        yield _client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-required-version = "24.3.0"
+required-version = "24.4.2"
 target-version = ["py310", "py311", "py312"]
 line-length = 88
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-ruff==0.3.6
-black==24.3.0
-pytest==8.1.1
+ruff==0.5.1
+black==24.4.2
+pytest==8.1.2
 
 Flask==3.0.3
 gunicorn==22.0.0


### PR DESCRIPTION
## Application Changes

- Change the database queries and application logic for the panelist "Perfect Score Counts" and "Single Appearance" reports to allow the application to experimentally support MariaDB 11.4.2

## Development Changes

- Upgrade ruff from 0.3.6 to 0.5.1
- Upgrade black from 24.3.0 to 24.4.2
- Upgrade pytest from 8.1.1 to 8.1.2