### PR TITLE
Add Umami analytics support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Ruff
+.ruff_cache
+
 # C extensions
 *.so
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 2.11.0
+
+### Application Changes
+
+- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:
+
+| Config Key | Description |
+| ---------- | ----------- |
+| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
+| `url` | URL of the Umami analytics script |
+| `data_website_id` | Umami Site ID |
+| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
+| `data_host_url` | Override the location where Umami data is sent to |
+| `data_domains` | Comma-delimited list of domains where the Umami script should be active |
+
 ## 2.10.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,10 +25,12 @@ from .scorekeepers.routes import blueprint as scorekeepers_bp
 from .shows.redirects import blueprint as shows_redirects_bp
 from .shows.routes import blueprint as shows_bp
 from .sitemaps.routes import blueprint as sitemaps_bp
+from .utility import format_umami_analytics
 from .version import APP_VERSION
 
 
 def create_app():
+    """Create Flask application."""
     app = Flask(__name__)
     app.url_map.strict_slashes = False
 
@@ -48,7 +50,6 @@ def create_app():
 
     # Set up Jinja globals
     app.jinja_env.globals["app_version"] = APP_VERSION
-    app.jinja_env.globals["date_string_to_date"] = utility.date_string_to_date
     app.jinja_env.globals["current_year"] = utility.current_year
     app.jinja_env.globals["rank_map"] = RANK_MAP
     app.jinja_env.globals["rendered_at"] = utility.generate_date_time_stamp
@@ -56,6 +57,10 @@ def create_app():
     app.jinja_env.globals["time_zone"] = _config["settings"]["app_time_zone"]
     app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
         "ga_property_code", ""
+    )
+    umami = _config["settings"].get("umami_analytics", None)
+    app.jinja_env.globals["umami_analytics"] = format_umami_analytics(
+        umami_analytics=umami
     )
     app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
     app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,6 +26,11 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+
+    {% if umami_analytics %}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}
     {% endblock head %}
 </head>
 

--- a/app/utility.py
+++ b/app/utility.py
@@ -18,6 +18,33 @@ from mysql.connector import DatabaseError, connect
 _utc_timezone = pytz.timezone("UTC")
 
 
+def format_umami_analytics(umami_analytics: dict = None) -> str:
+    """Return formatted string for Umami Analytics."""
+    if not umami_analytics:
+        return None
+
+    _enabled = bool(umami_analytics.get("_enabled", False))
+
+    if not _enabled:
+        return None
+
+    url = umami_analytics.get("url")
+    website_id = umami_analytics.get("data_website_id")
+    auto_track = bool(umami_analytics.get("data_auto_track", True))
+    host_url = umami_analytics.get("data_host_url")
+    domains = umami_analytics.get("data_domains")
+
+    if url and website_id:
+        host_url_prop = f'data-host-url="{host_url}"' if host_url else ""
+        auto_track_prop = f'data-auto-track="{str(auto_track).lower()}"'
+        domains_prop = f'data-domains="{domains}"' if domains else ""
+
+        props = " ".join([host_url_prop, auto_track_prop, domains_prop])
+        return f'<script defer src="{url}" data-website-id="{website_id}" {props.strip()}></script>'
+
+    return None
+
+
 def cmp(object_a, object_b):
     """Replacement for built-in function cmp that was removed in Python 3.
 
@@ -54,13 +81,15 @@ def current_year(time_zone: pytz.timezone = _utc_timezone):
     return now.strftime("%Y")
 
 
-def date_string_to_date(**kwargs):
+def date_string_to_date(**kwargs) -> datetime | None:
     """Used to convert an ISO-style date string into a datetime object."""
     if "date_string" in kwargs and kwargs["date_string"]:
         try:
-            return datetime.datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
+            date_object = datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
         except ValueError:
             return None
+
+        return date_object
 
     return None
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "2.10.0"
+APP_VERSION = "2.11.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -20,6 +20,14 @@
         "site_url": "",
         "stats_url": "",
         "ga_property_code": null,
+        "umami_analytics": {
+            "_enabled": false,
+            "url": "",
+            "data_website_id": "",
+            "data_domains": "",
+            "data_host_url": "",
+            "data_auto_track": true
+        },
         "time_zone": "UTC",
         "mastodon_url": "",
         "mastodon_user": "",


### PR DESCRIPTION
## Application Changes

- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:

| Config Key | Description |
| ---------- | ----------- |
| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
| `url` | URL of the Umami analytics script |
| `data_website_id` | Umami Site ID |
| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
| `data_host_url` | Override the location where Umami data is sent to |
| `data_domains` | Comma-delimited list of domains where the Umami script should be active |