### PR TITLE
Fix Umami Analytics configuration parsing and integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 3.0.3
+
+### Application Changes
+
+- Fix issue where Umami Analytics configuration was not read in properly, thus causing the snippet to be added to the rendered page when enabled
+- Removed `utility.format_umami_analytics()` as it is no longer in use
+
 ## 3.0.2
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,7 +25,6 @@ from .scorekeepers.routes import blueprint as scorekeepers_bp
 from .shows.redirects import blueprint as shows_redirects_bp
 from .shows.routes import blueprint as shows_bp
 from .sitemaps.routes import blueprint as sitemaps_bp
-from .utility import format_umami_analytics
 from .version import APP_VERSION
 
 
@@ -58,10 +57,7 @@ def create_app():
     app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
         "ga_property_code", ""
     )
-    umami = _config["settings"].get("umami_analytics", None)
-    app.jinja_env.globals["umami_analytics"] = format_umami_analytics(
-        umami_analytics=umami
-    )
+    app.jinja_env.globals["umami"] = _config["settings"]["umami"]
     app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
     app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")
     app.jinja_env.globals["graphs_url"] = _config["settings"].get("graphs_url", "")

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,24 @@ def load_config(
         settings_config.get("use_decimal_scores", False)
     )
 
+    # Read in Umami Analytics settings
+    if "umami_analytics" in settings_config:
+        _umami = dict(settings_config["umami_analytics"])
+        settings_config["umami"] = {
+            "enabled": bool(_umami.get("enabled", False)),
+            "url": _umami.get("url"),
+            "website_id": _umami.get("data_website_id"),
+            "auto_track": bool(_umami.get("data_auto_track", True)),
+            "host_url": _umami.get("data_host_url"),
+            "domains": _umami.get("data_domains"),
+        }
+
+        del settings_config["umami_analytics"]
+    else:
+        settings_config["umami"] = {
+            "enabled": False,
+        }
+
     return {
         "database": database_config,
         "settings": settings_config,

--- a/app/utility.py
+++ b/app/utility.py
@@ -18,33 +18,6 @@ from mysql.connector import DatabaseError, connect
 _utc_timezone = pytz.timezone("UTC")
 
 
-def format_umami_analytics(umami_analytics: dict = None) -> str:
-    """Return formatted string for Umami Analytics."""
-    if not umami_analytics:
-        return None
-
-    _enabled = bool(umami_analytics.get("_enabled", False))
-
-    if not _enabled:
-        return None
-
-    url = umami_analytics.get("url")
-    website_id = umami_analytics.get("data_website_id")
-    auto_track = bool(umami_analytics.get("data_auto_track", True))
-    host_url = umami_analytics.get("data_host_url")
-    domains = umami_analytics.get("data_domains")
-
-    if url and website_id:
-        host_url_prop = f'data-host-url="{host_url}"' if host_url else ""
-        auto_track_prop = f'data-auto-track="{str(auto_track).lower()}"'
-        domains_prop = f'data-domains="{domains}"' if domains else ""
-
-        props = " ".join([host_url_prop, auto_track_prop, domains_prop])
-        return f'<script defer src="{url}" data-website-id="{website_id}" {props.strip()}></script>'
-
-    return None
-
-
 def cmp(object_a, object_b):
     """Replacement for built-in function cmp that was removed in Python 3.
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "3.0.2"
+APP_VERSION = "3.0.3"


### PR DESCRIPTION
- Fix issue where Umami Analytics configuration was not read in properly, thus causing the snippet to be added to the rendered page when enabled
- Removed `utility.format_umami_analytics()` as it is no longer in use