### PR TITLE
Add new locations and shows reports, migrate from Black to Ruff for linting/formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 3.1.0 (pre-release)
+
+### Application Changes
+
+- Adding new reports
+  - Locations
+    - Show Locations: Home vs Away
+  - Shows
+    - Lightning Round All Panelists Answering the Same Number of Questions Correct
+
+### Development Changes
+
+- Upgrade pytest from 8.3.3 to 8.3.4
+- Upgrade ruff from 0.7.4 to 0.9.4
+- Remove black from required development packages as part of migrating entirely to Ruff
+- Ran `ruff format` to format Python code files using the Ruff 2025 Style Guide
+
 ## 3.0.5
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 3.1.0 (pre-release)
+## 3.1.0
 
 ### Application Changes
 
@@ -9,6 +9,7 @@
     - Show Locations: Home vs Away
   - Shows
     - Lightning Round All Panelists Answering the Same Number of Questions Correct
+    - Shows with a Guest Host and a Guest Scorekeeper
 
 ### Development Changes
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Core Application for Wait Wait Reports."""
+
 from flask import Flask
 
 from app import config, utility

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=R1731
 """Configuration Loading and Parsing for Wait Wait Reports."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -5,7 +5,6 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Shared Dictionaries for Wait Wait Reports."""
 
-
 RANK_MAP: dict[str, str] = {
     "1": "First",
     "1t": "First Tied",

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Error Handlers Module for Wait Wait Reports."""
+
 from typing import Literal
 
 from flask import render_template

--- a/app/guests/redirects.py
+++ b/app/guests/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Guests Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/guests/reports/best_of_only.py
+++ b/app/guests/reports/best_of_only.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Guest Best Of Only Appearances Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/guests/reports/most_appearances.py
+++ b/app/guests/reports/most_appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Guest Most Appearances Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/guests/reports/scores.py
+++ b/app/guests/reports/scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Guest Scores Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Guests Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template
 

--- a/app/hosts/redirects.py
+++ b/app/hosts/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Hosts Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/hosts/reports/appearances.py
+++ b/app/hosts/reports/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Hosts Appearances Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Hosts Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template
 

--- a/app/locations/redirects.py
+++ b/app/locations/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Locations Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/locations/reports/average_scores.py
+++ b/app/locations/reports/average_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Location Score Breakdown Report Functions."""
+
 from decimal import Decimal
 from typing import Any
 

--- a/app/locations/reports/home_vs_away.py
+++ b/app/locations/reports/home_vs_away.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2018-2025 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Location Home vs Away Report Functions."""
+
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
+
+def retrieve_location_home_vs_away(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[dict[str, int]] | None:
+    """Retrieve counts of home versus away shows broken down by year."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT DISTINCT YEAR(showdate) FROM ww_shows
+        ORDER BY YEAR(showdate) ASC;
+        """
+    cursor = database_connection.cursor(dictionary=False)
+    cursor.execute(query)
+    results = cursor.fetchall()
+
+    if not results:
+        return None
+
+    years = [year[0] for year in results]
+
+    counts = []
+    for year in years:
+        query = """
+            SELECT (
+                SELECT COUNT(s.showid)
+                FROM ww_shows s
+                JOIN ww_showlocationmap lm ON lm.showid = s.showid
+                JOIN ww_locations l ON l.locationid = lm.locationid
+                WHERE YEAR(s.showdate) = %s
+                AND s.bestof = 0
+                AND s.repeatshowid IS NULL
+                AND l.city = 'Chicago'
+                AND l.state = 'IL'
+            )  AS 'home', (
+                SELECT COUNT(s.showid)
+                FROM ww_shows s
+                JOIN ww_showlocationmap lm ON lm.showid = s.showid
+                JOIN ww_locations l ON l.locationid = lm.locationid
+                WHERE YEAR(s.showdate) = %s
+                AND s.bestof = 0
+                AND s.repeatshowid IS NULL
+                AND l.city <> 'Chicago'
+                AND l.state <> 'IL'
+            ) AS 'away';
+            """
+        cursor = database_connection.cursor(dictionary=True)
+        cursor.execute(
+            query,
+            (
+                year,
+                year,
+            ),
+        )
+        result = cursor.fetchone()
+
+        if not result:
+            counts.append({"year": year, "home": None, "away": None})
+        else:
+            counts.append(
+                {"year": year, "home": result["home"], "away": result["away"]}
+            )
+
+    return counts

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -4,10 +4,12 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Locations Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template
 
 from .reports.average_scores import retrieve_average_scores_by_location
+from .reports.home_vs_away import retrieve_location_home_vs_away
 
 blueprint = Blueprint("locations", __name__, template_folder="templates")
 
@@ -30,3 +32,13 @@ def average_scores_by_location() -> str:
     return render_template(
         "locations/average-scores-by-location.html", locations=_locations
     )
+
+
+@blueprint.route("/home-vs-away")
+def home_vs_away() -> str:
+    """View: Show Locations: Home vs Away."""
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _show_counts = retrieve_location_home_vs_away(
+        database_connection=_database_connection
+    )
+    return render_template("locations/home-vs-away.html", show_counts=_show_counts)

--- a/app/locations/templates/locations/_index.html
+++ b/app/locations/templates/locations/_index.html
@@ -34,6 +34,19 @@
                         Fill-in-the-Blank format.
                     </p>
                 </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
+                    <a href="{{ url_for('locations.home_vs_away') }}">Home vs Away</a>
+                </h3>
+                <div class="description">
+                    <p>
+                        This report provides a count of shows recorded at home (any venue
+                        or studio located in Chicago, Illinois) and away, broken down by
+                        year.
+                    </p>
+                </div>
+            </li>
         </ul>
     </div>
 </div>

--- a/app/locations/templates/locations/home-vs-away.html
+++ b/app/locations/templates/locations/home-vs-away.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% set page_title = "Show Locations: Home vs Away" %}
+{% block title %}{{ page_title }} | Locations{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('locations.index') }}">Locations</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        This report provides a count of shows recorded at home (any venue or studio
+        located in Chicago, Illinois) and away, broken down by year.
+    </p>
+</div>
+
+{% if show_counts %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="date year">
+                    <col class="count">
+                    <col class="count">
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th scope="col">Year</th>
+                        <th scope="col">Home</th>
+                        <th scope="col">Away</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for count in show_counts %}
+                    <tr>
+                        <td>{{ count["year"] }}</td>
+                        <td>{{ count["home"] }}</td>
+                        <td>{{ count["away"] }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col">Year</th>
+                        <th scope="col">Home</th>
+                        <th scope="col">Away</th>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Routes for Wait Wait Reports."""
+
 from pathlib import Path
 
 from flask import Blueprint, Response, render_template, send_file

--- a/app/panelists/redirects.py
+++ b/app/panelists/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Panelists Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/panelists/reports/aggregate_scores.py
+++ b/app/panelists/reports/aggregate_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Aggregate Scores Report Functions."""
+
 from decimal import Decimal
 from typing import Any
 

--- a/app/panelists/reports/appearances.py
+++ b/app/panelists/reports/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Appearances Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/appearances_by_year.py
+++ b/app/panelists/reports/appearances_by_year.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Appearances by Year Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/average_scores_by_year.py
+++ b/app/panelists/reports/average_scores_by_year.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelists Average Scores Report Functions."""
+
 from decimal import Decimal
 
 from flask import current_app

--- a/app/panelists/reports/bluff_stats.py
+++ b/app/panelists/reports/bluff_stats.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Bluff the Listener Statistics Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/common.py
+++ b/app/panelists/reports/common.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Common Panelist Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/debut_by_year.py
+++ b/app/panelists/reports/debut_by_year.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Debut by Year Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/first_appearance_wins.py
+++ b/app/panelists/reports/first_appearance_wins.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist First Appearance Wins."""
+
 from decimal import Decimal
 
 from flask import current_app

--- a/app/panelists/reports/gender_stats.py
+++ b/app/panelists/reports/gender_stats.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panel Gender Mix Report Functions."""
+
 from decimal import Decimal
 from typing import Any
 

--- a/app/panelists/reports/panelist_vs_panelist.py
+++ b/app/panelists/reports/panelist_vs_panelist.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist vs Panelist Report Functions."""
+
 from typing import Any
 
 from flask import current_app

--- a/app/panelists/reports/panelist_vs_panelist_scoring.py
+++ b/app/panelists/reports/panelist_vs_panelist_scoring.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist vs Panelist Scoring Report Functions."""
+
 from typing import Any
 
 from flask import current_app

--- a/app/panelists/reports/perfect_scores.py
+++ b/app/panelists/reports/perfect_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Perfect Scores Report Functions."""
+
 from flask import current_app
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection

--- a/app/panelists/reports/rankings_summary.py
+++ b/app/panelists/reports/rankings_summary.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Rankings Summary Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/panelists/reports/single_appearance.py
+++ b/app/panelists/reports/single_appearance.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Single Appearance Report Functions."""
+
 from typing import Any
 
 from flask import current_app

--- a/app/panelists/reports/stats_summary.py
+++ b/app/panelists/reports/stats_summary.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Statistics Summary Report Functions."""
+
 from decimal import Decimal
 from typing import Any
 

--- a/app/panelists/reports/streaks.py
+++ b/app/panelists/reports/streaks.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Panelist Win/Loss Streaks Report Functions."""
+
 from typing import Any
 
 from flask import current_app

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Panelists Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template, request
 

--- a/app/scorekeepers/redirects.py
+++ b/app/scorekeepers/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Scorekeepers Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/scorekeepers/reports/appearances.py
+++ b/app/scorekeepers/reports/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Scorekeeper Appearances Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/scorekeepers/reports/introductions.py
+++ b/app/scorekeepers/reports/introductions.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Scorekeeper Introductions Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Scorekeepers Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template
 

--- a/app/shows/redirects.py
+++ b/app/shows/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Shows Redirect Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, url_for
 
 from app.utility import redirect_url

--- a/app/shows/reports/all_women_panel.py
+++ b/app/shows/reports/all_women_panel.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM All Women Panel Report Functions."""
+
 from flask import current_app
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection

--- a/app/shows/reports/guest_host.py
+++ b/app/shows/reports/guest_host.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Guest Hosts Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/shows/reports/guest_host_scorekeeper.py
+++ b/app/shows/reports/guest_host_scorekeeper.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2018-2025 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Show Guest Host and Scorekeeper Report Functions."""
+
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
+from app.shows.reports import show_details
+
+
+def retrieve_shows_guest_host_scorekeeper(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[dict]:
+    """Retrieve a list of shows with a guest host and guest scorekeeper."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT s.showid, s.showdate, s.bestof, s.repeatshowid, h.host,
+        h.hostslug, hm.guest AS host_guest, sk.scorekeeper,
+        sk.scorekeeperslug, skm.guest AS scorekeeper_guest, l.venue,
+        l.city, l.state
+        FROM ww_showhostmap hm
+        JOIN ww_hosts h ON h.hostid = hm.hostid
+        JOIN ww_showskmap skm ON skm.showid = hm.showid
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        JOIN ww_shows s ON s.showid = hm.showid
+        JOIN ww_showlocationmap lm ON lm.showid = hm.showid
+        JOIN ww_locations l ON l.locationid = lm.locationid
+        WHERE hm.guest = 1 AND skm.guest = 1
+        ORDER BY s.showdate ASC;
+        """
+    cursor = database_connection.cursor(dictionary=True)
+    cursor.execute(query)
+    result = cursor.fetchall()
+
+    if not result:
+        return None
+
+    shows = []
+    for row in result:
+        show_id = row["showid"]
+        shows.append(
+            {
+                "date": row["showdate"].isoformat(),
+                "best_of": bool(row["bestof"]),
+                "repeat": bool(row["repeatshowid"]),
+                "location": {
+                    "venue": row["venue"],
+                    "city": row["city"],
+                    "state": row["state"],
+                },
+                "host": row["host"],
+                "host_slug": row["hostslug"],
+                "host_guest": row["host_guest"],
+                "scorekeeper": row["scorekeeper"],
+                "scorekeeper_slug": row["scorekeeperslug"],
+                "scorekeeper_guest": bool(row["scorekeeper_guest"]),
+                "panelists": show_details.retrieve_show_panelists(
+                    show_id, database_connection
+                ),
+                "guests": show_details.retrieve_show_guests(
+                    show_id, database_connection
+                ),
+            }
+        )
+
+    return shows

--- a/app/shows/reports/guest_scorekeeper.py
+++ b/app/shows/reports/guest_scorekeeper.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Guest Scorekeeper Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/shows/reports/guests_vs_bluffs.py
+++ b/app/shows/reports/guests_vs_bluffs.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Not My Job Guest Wins Rate vs Bluff the Listener Wins Rate Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/shows/reports/info.py
+++ b/app/shows/reports/info.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Description and Notes Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/shows/reports/panel_gender_mix.py
+++ b/app/shows/reports/panel_gender_mix.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=C0301
 """WWDTM Show Panel Gender Mix Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=C0301
 """WWDTM Show Scoring Reports Functions."""
+
 from decimal import Decimal
 
 from flask import current_app

--- a/app/shows/reports/search_multiple_panelists.py
+++ b/app/shows/reports/search_multiple_panelists.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Search Shows by Multiple Selected Panelists Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/shows/reports/show_counts.py
+++ b/app/shows/reports/show_counts.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Counts Report Functions."""
+
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 

--- a/app/shows/reports/show_details.py
+++ b/app/shows/reports/show_details.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """WWDTM Show Details Report Functions."""
+
 from typing import Any
 
 from mysql.connector.connection import MySQLConnection

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Shows Routes for Wait Wait Reports."""
+
 import mysql.connector
 from flask import Blueprint, current_app, render_template, request
 
@@ -14,6 +15,7 @@ from .reports.guests_vs_bluffs import retrieve_bluff_stats, retrieve_not_my_job_
 from .reports.info import retrieve_show_descriptions, retrieve_show_notes
 from .reports.lightning_round import (
     shows_ending_with_three_way_tie,
+    shows_lightning_round_answering_same_number_correct,
     shows_lightning_round_start_zero,
     shows_lightning_round_zero_correct,
     shows_starting_ending_three_way_tie,
@@ -105,6 +107,21 @@ def highest_score_equals_sum_other_scores() -> str:
 
     return render_template(
         "shows/highest-score-equals-sum-other-scores.html", shows=_shows
+    )
+
+
+@blueprint.route("/lightning-round-answering-same-number-correct")
+def lightning_round_answering_same_number_correct() -> str:
+    """View: Lightning Round Panelists Answering the Same Number of Questions Correct."""
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _shows = shows_lightning_round_answering_same_number_correct(
+        database_connection=_database_connection,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
+    _database_connection.close()
+
+    return render_template(
+        "shows/lightning-round-answering-same-number-correct.html", shows=_shows
     )
 
 

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -10,6 +10,7 @@ from flask import Blueprint, current_app, render_template, request
 
 from .reports.all_women_panel import retrieve_shows_all_women_panel
 from .reports.guest_host import retrieve_shows_guest_host
+from .reports.guest_host_scorekeeper import retrieve_shows_guest_host_scorekeeper
 from .reports.guest_scorekeeper import retrieve_shows_guest_scorekeeper
 from .reports.guests_vs_bluffs import retrieve_bluff_stats, retrieve_not_my_job_stats
 from .reports.info import retrieve_show_descriptions, retrieve_show_notes
@@ -381,6 +382,18 @@ def shows_with_guest_host() -> str:
     _database_connection.close()
 
     return render_template("shows/shows-with-guest-host.html", shows=_shows)
+
+
+@blueprint.route("/shows-with-guest-host-scorekeeper")
+def shows_with_guest_host_scorekeeper() -> str:
+    """View: Shows with a Guest Host Report."""
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _shows = retrieve_shows_guest_host_scorekeeper(
+        database_connection=_database_connection
+    )
+    _database_connection.close()
+
+    return render_template("shows/shows-with-guest-host-scorekeeper.html", shows=_shows)
 
 
 @blueprint.route("/shows-with-guest-scorekeeper")

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -48,7 +48,7 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.highest_score_equals_sum_other_scores') }}">Highest
-                        Score Equals Sum of Other Scores</a>
+                        Score Equals the Sum of Other Scores</a>
                 </h3>
                 <div class="description">
                     This report provides a list of shows in which the highest panelist
@@ -63,6 +63,17 @@
                 <div class="description">
                     This report provides a list of shows in which all three panelists
                     finished the Lightning Fill-in-the Blank segment in a three-way tie.
+                </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
+                    <a href="{{ url_for('shows.lightning_round_answering_same_number_correct') }}">Lightning
+                        Round All Panelists Answering the Same Number of Questions Correct</a>
+                </h3>
+                <div class="description">
+                    This report provides a list of shows in which all three panelists
+                    answered the same number of Lightning Fill-in-the-Blank questions
+                    correct.
                 </div>
             </li>
             <li class="list-group-item">

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -231,6 +231,16 @@
             </li>
             <li class="list-group-item">
                 <h3 class="title">
+                    <a href="{{ url_for('shows.shows_with_guest_host_scorekeeper') }}">Shows with a Guest Host
+                        and a Guest Scorekeeper</a>
+                </h3>
+                <div class="description">
+                    This report provides a list of all shows, including Best Of and Repeat
+                    shows, that have both a guest host and a guest scorekeeper.
+                </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
                     <a href="{{ url_for('shows.shows_with_guest_scorekeeper') }}">Shows with a Guest
                         Scorekeeper</a>
                 </h3>

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% set page_title = "Lightning Round All Panelists Answering the Same Number of Questions Correct" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        This report provides a list of shows in which all three panelists
+        answered the same number of Lightning Fill-in-the-Blank questions
+        correct.
+    </p>
+</div>
+
+{% if shows %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="date">
+                    <col class="name panelist">
+                    <col class="score">
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th scope="col">Show Date</th>
+                        <th scope="col">Panelists</th>
+                        <th scope="col">Correct Answers</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for show in shows %}
+                    <tr>
+                        <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>
+                            <ul class="no-bullets">
+                                {% for panelist in show.panelists %}
+                                <li> {{ panelist.name }}</li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        <td>{{ "{:f}".format(show.correct_decimal.normalize()) if use_decimal_scores else show.correct }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                {% if shows | length >= 10 %}
+                <tfoot>
+                    <tr>
+                        <th scope="col">Show Date</th>
+                        <th scope="col">Panelists</th>
+                        <th scope="col">Correct Answers</th>
+                    </tr>
+                </tfoot>
+                {% endif %}
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/shows/templates/shows/shows-with-guest-host-scorekeeper.html
+++ b/app/shows/templates/shows/shows-with-guest-host-scorekeeper.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+{% set page_title = "Shows with a Guest Host and a Guest Scorekeeper" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        This report provides a list of all shows, including Best Of and Repeat
+        shows, that have both a guest host and a guest scorekeeper.
+    </p>
+</div>
+
+{% if shows %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="date">
+                    <col class="boolean">
+                    <col class="name host">
+                    <col class="name scorekeeper">
+                    <col class="name venue">
+                    <col class="name panelist">
+                    <col class="name guest">
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th scope="col">Date</th>
+                        <th scope="col">Best Of/Repeat</th>
+                        <th scope="col">Host</th>
+                        <th scope="col">Scorekeeper</th>
+                        <th scope="col">Location</th>
+                        <th scope="col">Panelists</th>
+                        <th scope="col">Guest(s)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for show in shows %}
+                    <tr>
+                        <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        {% if show.best_of and show.repeat %}
+                        <td>Best Of / Repeat</td>
+                        {% elif show.best_of and not show.repeat %}
+                        <td>Best Of</td>
+                        {% elif show.repeat and not show.best_of %}
+                        <td>Repeat</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if show.host_guest %}
+                        <td><b>{{ show.host }}</b></td>
+                        {% else %}
+                        <td>{{ show.host }}</td>
+                        {% endif %}
+                        {% if show.scorekeeper_guest %}
+                        <td><b>{{ show.scorekeeper }}</b></td>
+                        {% else %}
+                        <td>{{ show.scorekeeper }}</td>
+                        {% endif %}
+                        {% if show.location.venue and show.location.city and show.location.city %}
+                        <td>{{ show.location.venue }} ({{ show.location.city }}, {{ show.location.state }})</td>
+                        {% elif show.location.venue and (not show.location.city or not show.location.state) %}
+                        <td>{{ show.location.venue }}</td>
+                        {% elif show.location.city %}
+                        <td>{{ show.location.city }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if show.panelists %}
+                        <td>
+                            <ul class="no-bullets">
+                                {% for panelist in show.panelists %}
+                                <li>{{ panelist.name }}</li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if show.guests %}
+                        <td>
+                            <ul class="no-bullets">
+                                {% for guest in show.guests %}
+                                <li>{{ guest.name }}</li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                {% if shows | length >= 10 %}
+                <tfoot>
+                    <tr>
+                        <th scope="col">Date</th>
+                        <th scope="col">Best Of/Repeat</th>
+                        <th scope="col">Location</th>
+                        <th scope="col">Host</th>
+                        <th scope="col">Scorekeeper</th>
+                        <th scope="col">Panelists</th>
+                        <th scope="col">Guest</th>
+                    </tr>
+                </tfoot>
+                {% endif %}
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Sitemap Routes for Wait Wait Reports."""
+
 from flask import Blueprint, Response, render_template
 
 blueprint = Blueprint("sitemaps", __name__, template_folder="templates")

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "3.0.5"
+APP_VERSION = "3.1.0"

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """pytest conftest.py File."""
+
 import pytest
 from flask import Flask
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,10 @@
-[tool.black]
-required-version = "24.10.0"
-target-version = ["py310", "py311", "py312", "py313"]
-line-length = 88
-
 [tool.pytest.ini_options]
 minversion = "8.3"
 filterwarnings = ["ignore::DeprecationWarning:mysql.*:"]
 norecursedirs = [".git", "venv", "dist", ".eggs", "wwdtm.egg-info"]
 
 [tool.ruff]
+required-version = ">= 0.9.0"
 target-version = "py310"
 
 exclude = [
@@ -22,7 +18,7 @@ exclude = [
     ".venv",
 ]
 
-line-length = 88 # Must agree with Black
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [

--- a/reports.py
+++ b/reports.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Bootstrap Script for Wait Wait Reports."""
+
 from app import create_app
 
 app = create_app()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
-ruff==0.7.4
-black==24.10.0
-pytest==8.3.3
+ruff==0.9.4
+pytest==8.3.4
 pytest-cov==5.0.0
 
 Flask==3.1.0

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Guests Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_guests_redirects.py
+++ b/tests/test_guests_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Guests Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Hosts Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_hosts_redirects.py
+++ b/tests/test_hosts_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Hosts Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Locations Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -17,6 +17,16 @@ def test_index(client: FlaskClient) -> None:
     assert b"Average Scores by Location" in response.data
 
 
+def test_home_vs_away(client: FlaskClient) -> None:
+    """Testing locations.routes.home_vs_away."""
+    response: TestResponse = client.get("/locations/home-vs-away")
+    assert response.status_code == 200
+    assert b"Home vs Away" in response.data
+    assert b"Year" in response.data
+    assert b"Home" in response.data
+    assert b"Away" in response.data
+
+
 def test_average_scores_by_location(client: FlaskClient) -> None:
     """Testing locations.routes.average_scores_by_location."""
     response: TestResponse = client.get("/locations/average-scores-by-location")

--- a/tests/test_locations_redirects.py
+++ b/tests/test_locations_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Locations Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Main Routes Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Main Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Panelists Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse

--- a/tests/test_panelists_redirects.py
+++ b/tests/test_panelists_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Panelists Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Scorekeepers Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_scorekeepers_redirects.py
+++ b/tests/test_scorekeepers_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Scorekeepers Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Shows Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -54,6 +54,20 @@ def test_highest_score_equals_sum_other_scores(client: FlaskClient) -> None:
     assert b"Rank" in response.data
 
 
+def test_lightning_round_answering_same_number_correct(client: FlaskClient) -> None:
+    """Testing shows.routes.lightning_round_answering_same_number_correct."""
+    response: TestResponse = client.get(
+        "/shows/lightning-round-answering-same-number-correct"
+    )
+    assert response.status_code == 200
+    assert (
+        b"Lightning Round All Panelists Answering the Same Number of Questions Correct"
+        in response.data
+    )
+    assert b"Panelists" in response.data
+    assert b"Correct Answers" in response.data
+
+
 def test_lightning_round_ending_three_way_tie(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_ending_three_way_tie."""
     response: TestResponse = client.get("/shows/lightning-round-ending-three-way-tie")

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -319,6 +319,15 @@ def test_shows_with_guest_host(client: FlaskClient) -> None:
     assert b"Guest(s)" in response.data
 
 
+def test_shows_with_guest_host_scorekeeper(client: FlaskClient) -> None:
+    """Testing shows.routes.shows_with_guest_host_scorekeeper."""
+    response: TestResponse = client.get("/shows/shows-with-guest-host-scorekeeper")
+    assert response.status_code == 200
+    assert b"Shows with a Guest Host and a Guest Scorekeeper" in response.data
+    assert b"Panelists" in response.data
+    assert b"Guest(s)" in response.data
+
+
 def test_shows_with_guest_scorekeeper(client: FlaskClient) -> None:
     """Testing shows.routes.shows_with_guest_scorekeeper."""
     response: TestResponse = client.get("/shows/shows-with-guest-scorekeeper")

--- a/tests/test_shows_redirects.py
+++ b/tests/test_shows_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Shows Redirects Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_sitemaps.py
+++ b/tests/test_sitemaps.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Sitemaps Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 


### PR DESCRIPTION
## Application Changes

- Adding new reports
  - Locations
    - Show Locations: Home vs Away
  - Shows
    - Lightning Round All Panelists Answering the Same Number of Questions Correct
    - Shows with a Guest Host and a Guest Scorekeeper

## Development Changes

- Upgrade pytest from 8.3.3 to 8.3.4
- Upgrade ruff from 0.7.4 to 0.9.4
- Remove black from required development packages as part of migrating entirely to Ruff
- Ran `ruff format` to format Python code files using the Ruff 2025 Style Guide