### PR TITLE
Relocate Bootstrap and app JS, corrected Umami include in error page...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Corrected Umami Analytics include for error page template
 - Update Bootstrap icon classes to include `.bi`
 
+### Component Changes
+
+- Set Jinja2 version to `~=3.1.6`
+
 ## 3.2.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **Note:** In the near future, all reports will require version 4.7 of the [Wait Wait Stats Database](https://github.com/questionlp/wwdtm_database) and all reports that make use of panelist scores will be based on decimal score columns. Code paths that check for use of the decimal scores columns will be updated to remove references to the non-decimal score columns.
 
+## 3.2.1
+
+### Application Changes
+
+- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
+
 ## 3.2.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
 - Corrected Umami Analytics include for error page template
+- Update Bootstrap icon classes to include `.bi`
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Application Changes
 
 - Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
+- Corrected Umami Analytics include for error page template
 
 ## 3.2.0
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Reports</title>
     {% include "core/head.html" with context %}
+    {% include "core/init_js.html" %}
 </head>
 
 <body class="d-flex flex-column h-100">
@@ -16,7 +17,5 @@
     </main>
 
     {% include "core/footer.html" %}
-
-    {% include "core/init_js.html" %}
 </body>
 </html>

--- a/app/templates/core/init_js.html
+++ b/app/templates/core/init_js.html
@@ -1,3 +1,2 @@
-<!--JavaScript at end of body for optimized loading-->
-<script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/app-code.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/app-code.js') }}"></script>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -9,7 +9,7 @@
                 data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar"
                 aria-controls="offcanvasNavbar" aria-expanded="false"
                 aria-label="Toggle navigation">
-                <i class="bi-list"></i>
+                <i class="bi bi-list"></i>
             </button>
             <h1><a class="navbar-brand" href="{{ url_for('main.index') }}">Wait Wait Reports</a></h1>
 
@@ -73,7 +73,7 @@
                             <button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
                                 id="bd-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown"
                                 data-bs-display="static" aria-label="Toggle Theme (Auto)">
-                                <i class="bi-circle-half"></i>
+                                <i class="bi bi-circle-half"></i>
                                 <span class="d-xl-none" id="bd-theme-text">Toggle theme</span>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end" id="theme-dropdown"
@@ -81,21 +81,21 @@
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="light" aria-pressed="false">
-                                        <i class="bi-sun-fill"></i>
+                                        <i class="bi bi-sun-fill"></i>
                                         Light
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="dark" aria-pressed="false">
-                                        <i class="bi-moon-stars-fill"></i>
+                                        <i class="bi bi-moon-stars-fill"></i>
                                         Dark
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center active"
                                         data-bs-theme-value="auto" aria-pressed="true">
-                                        <i class="bi-circle-half"></i>
+                                        <i class="bi bi-circle-half"></i>
                                         Auto
                                     </button>
                                 </li>

--- a/app/templates/errors/base.html
+++ b/app/templates/errors/base.html
@@ -15,9 +15,8 @@
     </script>
     {% endif %}
 
-    {% if umami_analytics %}
-    <!-- Umami Analytics -->
-    {{ umami_analytics | safe }}
+    {%- if umami %}
+    {% include "core/umami.html" %}
     {% endif %}
 </head>
 <body>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "3.2.0"
+APP_VERSION = "3.2.1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest==8.3.4
 pytest-cov==5.0.0
 
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 mysql-connector-python==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 mysql-connector-python==9.1.0


### PR DESCRIPTION
## Application Changes

- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
- Corrected Umami Analytics include for error page template
- Update Bootstrap icon classes to include `.bi`

## Component Changes

- Set Jinja2 version to `~=3.1.6`