### PR TITLE
Update Markdown to HTML filter for external links, update block_ai_scrapers logic

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[MESSAGE CONTROL]
+exclude = C0206, R0903
+
 [design]
 max-locals = 20
 max-module-lines = 1200

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,5 @@
             "source.fixAll": "explicit",
             "source.sortImports": "explicit",
         },
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "pylint.args": [
-        "--disable=C0206"
-    ]
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 **Note:** In the near future, all reports will require version 4.7 of the [Wait Wait Stats Database](https://github.com/questionlp/wwdtm_database) and all reports that make use of panelist scores will be based on decimal score columns. Code paths that check for use of the decimal scores columns will be updated to remove references to the non-decimal score columns.
 
+## 3.3.4
+
+### Application Changes
+
+- Update the Markdown to HTML filter to modify generated external links to open in a new window/tab and add the `bi-box-arrow-up-right` icon at the end of the link text
+- Update list of AI scraper user agents
+- Change the `block_ai_scrapers` logic so that if the configuration key is set to `true`, the action is set to `Disallow: /`. If the configuration key is set to `false`, the action is set to `Crawl-delay: 10`
+
 ## 3.3.3
 
 ### Component Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,8 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Core Application for Wait Wait Reports."""
 
+from urllib.parse import ParseResult, urlparse
+
 from flask import Flask
 
 from app import config, utility
@@ -63,7 +65,15 @@ def create_app():
     app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")
     app.jinja_env.globals["graphs_url"] = _config["settings"].get("graphs_url", "")
     app.jinja_env.globals["repo_url"] = _config["settings"].get("repo_url", "")
-    app.jinja_env.globals["site_url"] = _config["settings"].get("site_url", "")
+    _site_url: str = _config["settings"].get("site_url", "")
+    app.jinja_env.globals["site_url"] = _site_url
+
+    if _site_url.startswith("http"):
+        parsed_site_url: ParseResult = urlparse(_site_url)
+        if parsed_site_url.hostname:
+            _config["settings"]["site_hostname"] = parsed_site_url.hostname
+            app.jinja_env.globals["site_hostname"] = parsed_site_url.hostname
+
     app.jinja_env.globals["stats_url"] = _config["settings"].get("stats_url", "")
     app.jinja_env.globals["bluesky_url"] = _config["settings"].get("bluesky_url", "")
     app.jinja_env.globals["bluesky_user"] = _config["settings"].get("bluesky_user", "")

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -6,25 +6,35 @@ Sitemap: {{ site_url }}{{ url_for("sitemaps.panelists") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.scorekeepers") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.shows") }}
 
-{% if block_ai_scrapers %}
 User-agent: AI2Bot
 User-agent: Ai2Bot-Dolma
+User-agent: aiHitBot
 User-agent: Amazonbot
 User-agent: anthropic-ai
 User-agent: Applebot
 User-agent: Applebot-Extended
+User-agent: AwarioBot
+User-agent: AwarioRssBot
+User-agent: AwarioSmartBot
+User-agent: Brightbot 1.0
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ChatGPT-User
+User-agent: Claude-SearchBot
+User-agent: Claude-User
 User-agent: Claude-Web
 User-agent: ClaudeBot
 User-agent: cohere-ai
 User-agent: cohere-training-data-crawler
+User-agent: Cotoyogi
 User-agent: Crawlspace
 User-agent: Diffbot
 User-agent: DuckAssistBot
 User-agent: FacebookBot
+User-agent: Factset_spyderbot
+User-agent: FirecrawlAgent
 User-agent: FriendlyCrawler
+User-agent: Google-CloudVertexBot
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GoogleOther-Image
@@ -34,25 +44,38 @@ User-agent: iaskspider/2.0
 User-agent: ICC-Crawler
 User-agent: ImagesiftBot
 User-agent: img2dataset
+User-agent: imgproxy
 User-agent: ISSCyberRiskCrawler
 User-agent: Kangaroo Bot
+User-agent: meta-externalagent
 User-agent: Meta-ExternalAgent
+User-agent: meta-externalfetcher
 User-agent: Meta-ExternalFetcher
+User-agent: MistralAI-User/1.0
+User-agent: NovaAct
 User-agent: OAI-SearchBot
 User-agent: omgili
 User-agent: omgilibot
+User-agent: Operator
 User-agent: PanguBot
+User-agent: Perplexity-User
 User-agent: PerplexityBot
 User-agent: PetalBot
+User-agent: QualifiedBot
 User-agent: Scrapy
 User-agent: SemrushBot-OCOB
 User-agent: SemrushBot-SWA
 User-agent: Sidetrade indexer bot
+User-agent: TikTokSpider
 User-agent: Timpibot
 User-agent: VelenPublicWebCrawler
 User-agent: Webzio-Extended
+User-agent: wpbot
 User-agent: YouBot
+{% if block_ai_scrapers %}
 Disallow: /
+{% else %}
+Crawl-delay: 10
 {% endif %}
 
 User-agent: *

--- a/app/utility.py
+++ b/app/utility.py
@@ -6,6 +6,7 @@
 """Utility functions used by the Wait Wait Reports."""
 
 import json
+import re
 from datetime import datetime
 from functools import cmp_to_key
 from operator import itemgetter
@@ -73,9 +74,17 @@ def generate_date_time_stamp(time_zone: pytz.timezone = _utc_timezone):
     return now.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
-def md_to_html(text: str):
+def md_to_html(markdown_text: str):
     """Converts Markdown text into HTML."""
-    return markdown.markdown(text, output_format="html")
+    html_text = markdown.markdown(markdown_text, output_format="html")
+    site_url = current_app.jinja_env.globals["site_url"]
+
+    if html_text and site_url:
+        pattern = r'(<a\s+href="((?:(?!' + site_url + r').)*?)")>([^<]+)</a>'
+        replacement = r'\1 target="_blank">\3<i class="bi bi-box-arrow-up-right px-1" aria-hidden="true"></i></a>'
+        updated_html = re.sub(pattern, replacement, html_text, flags=re.DOTALL)
+
+    return updated_html
 
 
 def pretty_jsonify(data):

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "3.3.3"
+APP_VERSION = "3.3.4"


### PR DESCRIPTION
## Application Changes

- Update the Markdown to HTML filter to modify generated external links to open in a new window/tab and add the `bi-box-arrow-up-right` icon at the end of the link text
- Update list of AI scraper user agents
- Change the `block_ai_scrapers` logic so that if the configuration key is set to `true`, the action is set to `Disallow: /`. If the configuration key is set to `false`, the action is set to `Crawl-delay: 10`