### PR TITLE
Add "Support NPR" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.0.1
+
+### Application Changes
+
+- Add `support_npr_url` to the `app_settings` section in the `config.json` file
+- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`
+
 ## 4.0.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -81,6 +81,9 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["support_npr_url"] = _config["settings"].get(
+        "support_npr_url", ""
+    )
     app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
     app.jinja_env.globals["github_sponsor_url"] = _config["settings"].get(
         "github_sponsor_url", ""

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -8,6 +8,9 @@
                         <li><a href="{{ blog_url }}" target="_blank">Blog</a></li>
                         <li><a href="{{ graphs_url }}" target="_blank">Graphs</a></li>
                         <li><a href="{{ stats_url }}" target="_blank">Stats Page</a></li>
+                        {% if support_npr_url %}
+                        <li><a href="{{ support_npr_url }}" target="_blank">Support NPR</a></li>
+                        {% endif %}
                         {% if github_sponsor_url %}
                         <li><a href="{{ github_sponsor_url }}" target="_blank">GitHub Sponsor</a></li>
                         {% endif %}

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -49,6 +49,14 @@
                         <li class="nav-item d-block d-xl-none">
                             <a class="nav-link" href="{{ blog_url }}" target="_blank">Blog</a>
                         </li>
+                        {% if support_npr_url %}
+                        <li class="nav-item d-block d-xl-none">
+                            <hr>
+                        </li>
+                        <li class="nav-item d-block d-xl-none">
+                            <a class="nav-link" href="{{ support_npr_url }}" target="_blank">Support NPR</a>
+                        </li>
+                        {% endif %}
                         {% if github_sponsor_url or patreon_url %}
                         <li class="nav-item d-block d-xl-none">
                             <hr>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.0.0"
+APP_VERSION = "4.0.1"

--- a/config.json.dist
+++ b/config.json.dist
@@ -33,6 +33,7 @@
         "bluesky_user": "",
         "mastodon_url": "",
         "mastodon_user": "",
+        "support_npr_url": "",
         "patreon_url": "",
         "github_sponsor_url": "",
         "use_minified_css": true


### PR DESCRIPTION
### Application Changes

- Updated handling of Not My Job Guest score exception in both Shows and Guests details pages so that the `<span>` for the score exception only appears when there is a score exception. Previously, an empty `<span>` was needlessly rendered for all guest score entries
- - Add `support_npr_url` to the `app_settings` section in the `config.json` file
- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`