### PR TITLE
Add Panelists "Wins, Draws and Losses" report, update report descriptions for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.3.0
+
+### Application Changes
+
+- Adding new Panelists "Wins, Draws and Losses" report that includes the number of times a panelist finished in first place (win), finished tied for first (draw), or lost (all other positions)
+- Reworded the beginning of report descriptions for more consistency
+
 ## 4.2.1
 
 ### Application Changes

--- a/app/guests/templates/guests/_index.html
+++ b/app/guests/templates/guests/_index.html
@@ -26,7 +26,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Not My Job guest appearances with guest scores for a
+                        A table displaying Not My Job guest appearances with guest scores for a
                         selected year.
                     </p>
                     <p>
@@ -43,7 +43,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Not My Job guests who have only appeared on Best Of, or repeat
+                        A table displaying Not My Job guests who have only appeared on Best Of, or repeat
                         Best Of, shows while not appearing on any regular shows.
                     </p>
                     <p>
@@ -60,7 +60,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all Not My Job guests with a count of appearances on regular
+                        A table displaying all Not My Job guests with a count of appearances on regular
                         shows and appearances across all shows (including Best Of and repeat
                         shows).
                     <p>
@@ -77,7 +77,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Not My Job guests that currently do not have any scoring data entered
+                        A table displaying Not My Job guests that currently do not have any scoring data entered
                         into the Wait Wait Stats Database.
                     </p>
                     <p>
@@ -95,7 +95,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Not My Job guests who received a scoring exception from the show's
+                        A table displaying Not My Job guests who received a scoring exception from the show's
                         judge and scorekeeper.
                     </p>
                     <p>
@@ -119,7 +119,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all Not My Job guests who correctly answered all three Not My Job
+                        A table displaying all Not My Job guests who correctly answered all three Not My Job
                         questions or were awarded all three points via a scoring exception.
                     </p>
                 </div>
@@ -132,7 +132,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Not My Job guests who have won a prize for a listener
+                        A table displaying Not My Job guests who have won a prize for a listener
                         contestant by scoring two or more points or received a scoring exception
                         for a selected year.
                     </p>

--- a/app/guests/templates/guests/appearances-by-year.html
+++ b/app/guests/templates/guests/appearances-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Not My Job guest appearances with guest scores for a
+        A table displaying Not My Job guest appearances with guest scores for a
         selected year.
     </p>
     <p>

--- a/app/guests/templates/guests/best-of-only-not-my-job-guests.html
+++ b/app/guests/templates/guests/best-of-only-not-my-job-guests.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Not My Job guests who have only appeared on Best Of, or repeat
+        A table displaying Not My Job guests who have only appeared on Best Of, or repeat
         Best Of, shows while not appearing on any regular shows.
     </p>
     <p>

--- a/app/guests/templates/guests/most-appearances.html
+++ b/app/guests/templates/guests/most-appearances.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all Not My Job guests with a count of appearances on regular
+        A table displaying all Not My Job guests with a count of appearances on regular
         shows and appearances across all shows (including Best Of and repeat
         shows).
     <p>

--- a/app/guests/templates/guests/not-my-job-guests-missing-scores.html
+++ b/app/guests/templates/guests/not-my-job-guests-missing-scores.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Not My Job guests that currently do not have any scoring data entered
+        A table displaying Not My Job guests that currently do not have any scoring data entered
         into the Wait Wait Stats Database.
     </p>
     <p>

--- a/app/guests/templates/guests/not-my-job-scoring-exceptions.html
+++ b/app/guests/templates/guests/not-my-job-scoring-exceptions.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Not My Job guests who received a scoring exception from the show's
+        A table displaying Not My Job guests who received a scoring exception from the show's
         judge and scorekeeper.
     </p>
     <p>

--- a/app/guests/templates/guests/not-my-job-three-pointers.html
+++ b/app/guests/templates/guests/not-my-job-three-pointers.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all Not My Job guests who correctly answered all three Not My Job
+        A table displaying all Not My Job guests who correctly answered all three Not My Job
         questions or were awarded all three points via a scoring exception.
     </p>
 </div>

--- a/app/guests/templates/guests/wins-by-year.html
+++ b/app/guests/templates/guests/wins-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Not My Job guests who have won a prize for a listener
+        A table displaying Not My Job guests who have won a prize for a listener
         contestant by scoring two or more points or received a scoring exception
         for a selected year.
     </p>

--- a/app/hosts/templates/hosts/_index.html
+++ b/app/hosts/templates/hosts/_index.html
@@ -27,7 +27,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of show host appearance counts for regular, Best Of,
+                        A table displaying show host appearance counts for regular, Best Of,
                         repeat Best Ofs, repeat and all shows grouped by year.
                     </p>
                     <p>
@@ -46,7 +46,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A large table displaying each show host as rows and hosting appearance counts
+                        A table displaying each show host as rows and hosting appearance counts
                         for each year as columns. Hosting appearance counts includes regular shows and
                         all shows, with the count of all shows in parentheses.
                     </p>
@@ -64,7 +64,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of show hosts with their first and most recent appearances and
+                        A table displaying show hosts with their first and most recent appearances and
                         corresponding count of hosting appearances for both regular shows and all shows.
                     </p>
                     <p>
@@ -81,7 +81,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of appearances with show information, including location,
+                        A table displaying appearances with show information, including location,
                         scorekeeper, panelists and Not My Job guest(s), for a selected show host grouped
                         by year.
                     </p>
@@ -95,7 +95,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of show host debut appearances with show information, including
+                        A table displaying show host debut appearances with show information, including
                         location, scorekeeper, panelists and Not My Job guest(s), grouped by year.
                     </p>
                 </div>

--- a/app/hosts/templates/hosts/appearance-counts-by-year-grid.html
+++ b/app/hosts/templates/hosts/appearance-counts-by-year-grid.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A large table displaying each show host as rows and hosting appearance counts
+        A table displaying each show host as rows and hosting appearance counts
         for each year as columns. Hosting appearance counts includes regular shows and
         all shows, with the count of all shows in parentheses.
     </p>

--- a/app/hosts/templates/hosts/appearance-counts-by-year.html
+++ b/app/hosts/templates/hosts/appearance-counts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of show host appearance counts for regular, Best Of,
+        A table displaying show host appearance counts for regular, Best Of,
         repeat Best Ofs, repeat and all shows grouped by year.
     </p>
     <p>

--- a/app/hosts/templates/hosts/appearance-summary.html
+++ b/app/hosts/templates/hosts/appearance-summary.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of show hosts with their first and most recent appearances and
+        A table displaying show hosts with their first and most recent appearances and
         corresponding count of hosting appearances for both regular shows and all shows.
     </p>
     <p>

--- a/app/hosts/templates/hosts/appearances-by-year.html
+++ b/app/hosts/templates/hosts/appearances-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of appearances with show information, including location,
+        A table displaying appearances with show information, including location,
         scorekeeper, panelists and Not My Job guest(s), for a selected show host grouped
         by year.
     </p>

--- a/app/hosts/templates/hosts/debuts-by-year.html
+++ b/app/hosts/templates/hosts/debuts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of show host debut appearances with show information, including
+        A table displaying show host debut appearances with show information, including
         location, scorekeeper, panelists and Not My Job guest(s), grouped by year.
     </p>
 </div>

--- a/app/locations/templates/locations/_index.html
+++ b/app/locations/templates/locations/_index.html
@@ -26,7 +26,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of recording locations with venue name, city, state, average panelist
+                        A table displaying recording locations with venue name, city, state, average panelist
                         score and average panelist total score, and a count shows recorded at the
                         location. The locations are sorted in descending order based on average scores.
                     </p>
@@ -46,7 +46,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of the number of shows recorded at home (any venue or studio located in
+                        A table displaying the number of shows recorded at home (any venue or studio located in
                         Chicago, Illinois), away, and at home/remote studios, grouped by year.
                     </p>
                 </div>
@@ -59,7 +59,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of recording locations with counts for the number of regular,
+                        A table displaying recording locations with counts for the number of regular,
                         Best Of, repeat Best Ofs, repeat and all shows for each.
                     </p>
                     <p>
@@ -78,7 +78,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of states with recording counts for the number of regular, Best Of,
+                        A table displaying states with recording counts for the number of regular, Best Of,
                         repeat Best Ofs, repeat and all shows for each.
                     </p>
                     <p>
@@ -97,7 +97,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of show location recording counts for regular, Best Of,
+                        A table displaying show location recording counts for regular, Best Of,
                         repeat Best Ofs, repeat and all shows grouped by year.
                     </p>
                     <p>
@@ -116,7 +116,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of recordings including host, scorekeeper, panelists and Not My Job guest,
+                        A table displaying recordings including host, scorekeeper, panelists and Not My Job guest,
                         for a selected location grouped by year.
                     </p>
                 </div>

--- a/app/locations/templates/locations/average-scores-by-location.html
+++ b/app/locations/templates/locations/average-scores-by-location.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of recording locations with venue name, city, state, average panelist
+        A table displaying recording locations with venue name, city, state, average panelist
         score and average panelist total score, and a count shows recorded at the
         location. The locations are sorted in descending order based on average scores.
     </p>

--- a/app/locations/templates/locations/home-vs-away.html
+++ b/app/locations/templates/locations/home-vs-away.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of the number of shows recorded at home (any venue or studio located in
+        A table displaying the number of shows recorded at home (any venue or studio located in
         Chicago, Illinois), away, and at home/remote studios, grouped by year.
     </p>
 </div>

--- a/app/locations/templates/locations/recording-counts-by-location.html
+++ b/app/locations/templates/locations/recording-counts-by-location.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of recording locations with counts for the number of regular,
+        A table displaying recording locations with counts for the number of regular,
         Best Of, repeat Best Ofs, repeat and all shows for each.
     </p>
     <p>

--- a/app/locations/templates/locations/recording-counts-by-state.html
+++ b/app/locations/templates/locations/recording-counts-by-state.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of states with recording counts for the number of regular, Best Of,
+        A table displaying states with recording counts for the number of regular, Best Of,
         repeat Best Ofs, repeat and all shows for each.
     </p>
     <p>

--- a/app/locations/templates/locations/recording-counts-by-year.html
+++ b/app/locations/templates/locations/recording-counts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of show location recording counts for regular, Best Of,
+        A table displaying show location recording counts for regular, Best Of,
         repeat Best Ofs, repeat and all shows grouped by year.
     </p>
     <p>

--- a/app/locations/templates/locations/recordings-by-year.html
+++ b/app/locations/templates/locations/recordings-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of recordings including host, scorekeeper, panelists and Not My Job guest,
+        A table displaying recordings including host, scorekeeper, panelists and Not My Job guest,
         for a selected location grouped by year.
     </p>
 </div>

--- a/app/panelists/reports/wins_draws_losses.py
+++ b/app/panelists/reports/wins_draws_losses.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2018-2025 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Panelist Wins Report Functions."""
+
+from decimal import Decimal
+
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
+from . import common
+
+table_columns: dict[str, str] = {
+    "panelist": "Panelist",
+    "wins": "Wins",
+    "wins_percent": "Win %",
+    "draws": "Draws",
+    "draws_percent": "Draw %",
+    "losses": "Losses",
+    "losses_percent": "Loss %",
+    "total": "Total",
+}
+
+form_minimum_values: list[int] = [5, 10, 15, 20]
+
+
+def retrieve_panelist_wins_draws_losses(
+    panelist_id: int,
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> dict[str, int]:
+    """Retrieve wins, draws, losses and total counts for a given panelist."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT (
+            SELECT COUNT(pm.showpnlrank)
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.showpnlrank = '1'
+        ) AS 'wins', (
+            SELECT COUNT(pm.showpnlrank)
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.showpnlrank = '1t'
+        ) AS 'draws', (
+            SELECT COUNT(pm.showpnlrank)
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.showpnlrank IN ('2', '2t', '3')
+        ) AS 'losses';
+    """
+    cursor = database_connection.cursor(dictionary=True)
+    cursor.execute(
+        query,
+        (
+            panelist_id,
+            panelist_id,
+            panelist_id,
+        ),
+    )
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    _wins = result["wins"]
+    _draws = result["draws"]
+    _losses = result["losses"]
+    _total = result["wins"] + result["draws"] + result["losses"]
+
+    return {
+        "wins": _wins,
+        "wins_percent": round(Decimal((_wins / _total) * 100), 5),
+        "draws": _draws,
+        "draws_percent": round(Decimal((_draws / _total) * 100), 5),
+        "losses": _losses,
+        "losses_percent": round(Decimal((_losses / _total) * 100), 5),
+        "total": _total,
+    }
+
+
+def retrieve_all_wins_draws_losses(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+    minimum_total_count: int = 0,
+) -> dict[str, str | int | None]:
+    """Retrieves wins, draws, losses and total counts for all panelists."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    _panelists = common.retrieve_panelists(database_connection=database_connection)
+
+    if not _panelists:
+        return None
+
+    _counts = {}
+    for _panelist in _panelists:
+        panelist_counts = retrieve_panelist_wins_draws_losses(
+            panelist_id=_panelist["id"], database_connection=database_connection
+        )
+
+        if panelist_counts and panelist_counts["total"] >= minimum_total_count:
+            _counts[_panelist["slug"]] = {
+                "name": _panelist["name"],
+                "slug": _panelist["slug"],
+                "wins": panelist_counts["wins"],
+                "wins_percent": panelist_counts["wins_percent"],
+                "draws": panelist_counts["draws"],
+                "draws_percent": panelist_counts["draws_percent"],
+                "losses": panelist_counts["losses"],
+                "losses_percent": panelist_counts["losses_percent"],
+                "total": panelist_counts["total"],
+            }
+        # else:
+        #     _counts[_panelist["slug"]] = {
+        #         "name": _panelist["name"],
+        #         "slug": _panelist["slug"],
+        #         "wins": 0,
+        #         "wins_percent": Decimal(0),
+        #         "draws": 0,
+        #         "draws_percent": Decimal(0),
+        #         "losses": 0,
+        #         "losses_percent": Decimal(0),
+        #         "total": 0,
+        #     }
+
+    return _counts

--- a/app/panelists/templates/panelists/_index.html
+++ b/app/panelists/templates/panelists/_index.html
@@ -40,7 +40,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of panelist appearance counts for regular, Best Of,
+                        A table displaying panelist appearance counts for regular, Best Of,
                         repeat Best Ofs, repeat and all shows grouped by year.
                     </p>
                     <p>
@@ -59,7 +59,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A large table displaying each panelist as rows and appearance counts for each
+                        A table displaying each panelist as rows and appearance counts for each
                         year as columns. Appearance counts includes regular shows and all shows, with
                         the count of all shows in parentheses.
                     </p>
@@ -77,7 +77,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of appearances with show information, including location, show
+                        A table displaying appearances with show information, including location, show
                         host, scorekeeper, other panelists and Not My Job guest(s), for a selected
                         panelist grouped by year.
                     </p>
@@ -95,7 +95,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of average scores for a selected panelist broken out by year.
+                        A table displaying average scores for a selected panelist broken out by year.
                     </p>
                     
                     <p>
@@ -115,7 +115,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A large table display each panelist as rows and average scores for each year as
+                        A table displaying each panelist as rows and average scores for each year as
                         columns.
                     </p>
                     <p>
@@ -135,7 +135,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Bluff the Listener statistics, including the number of chosen stories,
+                        A table displaying Bluff the Listener statistics, including the number of chosen stories,
                         the number of correct stories, the number of regular Bluff the Listener
                         segments, and the number of Unique Best Of Bluff the Listener segments, for a
                         selected panelist, grouped by year.
@@ -150,7 +150,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Bluff the Listener statistics, including the number of chosen stories,
+                        A table displaying Bluff the Listener statistics, including the number of chosen stories,
                         the number of correct stories, the number of regular Bluff the Listener
                         segments, and the number of Unique Best Of Bluff the Listener segments, for all
                         panelists.
@@ -165,7 +165,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of Bluff the Listener statistics, including the number of chosen stories,
+                        A table displaying Bluff the Listener statistics, including the number of chosen stories,
                         the number of correct stories, the number of regular Bluff the Listener
                         segments, and the number of Unique Best Of Bluff the Listener segments, for a
                         selected year.
@@ -180,7 +180,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of panelist debut appearances with show information, including
+                        A table displaying panelist debut appearances with show information, including
                         the number of regular show appearances, host, scorekeeper, Not My Job guest(s),
                         grouped by year.
                     </p>
@@ -194,7 +194,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with their first and most recent appearances for both
+                        A table displaying panelists with their first and most recent appearances for both
                         regular shows and for all shows (including Best Of and repeat shows) and the
                         correponding number of appearances.
                     </p>
@@ -208,7 +208,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists who won outright or tied for first place on their debut
+                        A table displaying panelists who won outright or tied for first place on their debut
                         appearance. Information includes the show date, score at the start of the
                         Lightning Fill-in-the-Blank round, the number of correct answers, total score,
                         and ranking.
@@ -223,7 +223,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of the first appearance for all panelists, including their score
+                        A table displaying the first appearance for all panelists, including their score
                         at the start of the Lightning Fill-in-the-Blank round, the number of
                         correct answers, total score, and ranking.
                     </p>
@@ -234,7 +234,7 @@
                     <a href="{{ url_for('panelists.first_wins') }}">First Wins</a>
                 </h3>
                 <p>
-                    A list of panelists with the show they got their first outright win, by
+                    A table displaying panelists with the show they got their first outright win, by
                     finishing the Lightning Fill-in-the-Blank segment in first place, and
                     their first overall win, which includes outright wins and finishing
                     the segment tied for first.
@@ -252,7 +252,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with their average correct answers and number of appearances
+                        A table displaying panelists with their average correct answers and number of appearances
                         for a selected year. The list is sorted by average correct answers in descending
                         order.
                     </p>
@@ -272,7 +272,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with their average scores and number of appearances for a
+                        A table displaying panelists with their average scores and number of appearances for a
                         selected year. The list is sorted by average score in descending order.
                     </p>
                     <p>
@@ -291,7 +291,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with their longest string of appearances where they lost
+                        A table displaying panelists with their longest string of appearances where they lost
                         either by coming in tied for second or in third place, or losing outright by
                         coming in third place.
                     </p>
@@ -305,7 +305,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with the number of times their Bluff the Listener story was
+                        A table displaying panelists with the number of times their Bluff the Listener story was
                         chosen for a selected year. The list is sorted by the counts in descending
                         order.
                     </p>
@@ -323,7 +323,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with the number of times their Bluff the Listener story was
+                        A table displaying panelists with the number of times their Bluff the Listener story was
                         both chosen and was the correct story for a selected year. The list is sorted by
                         the counts in descending order.
                     </p>
@@ -341,7 +341,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with the number of times their Bluff the Listener story was
+                        A table displaying panelists with the number of times their Bluff the Listener story was
                         the correct story for a selected year. The list is sorted by the counts in
                         descending order.
                     </p>
@@ -359,7 +359,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with the number of times they have won outright, by coming in
+                        A table displaying panelists with the number of times they have won outright, by coming in
                         first place, or by coming either first place or tied for first place for a
                         selected year.
                     </p>
@@ -392,7 +392,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of comparisons of how well panelists performed against all other
+                        A table displaying comparisons of how well panelists performed against all other
                         panelists each have appeared with, grouped by panelist.
                     </p>
                     <p>
@@ -427,7 +427,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists who scored a total of 20 points, which Bill Kurtis calls
+                        A table displaying panelists who scored a total of 20 points, which Bill Kurtis calls
                         a "perfect score" with the number of times they have scored 20 points and the
                         number of times they have scored 20 points or more.
                     </p>
@@ -444,7 +444,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with the number of times each have finished the Lightning
+                        A table displaying panelists with the number of times each have finished the Lightning
                         Fill-in-the-Blank round in first, tied for first, second, tied for second, or
                         third place, and a total count.
                     </p>
@@ -461,7 +461,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists who have only appeared on the show one time along with their
+                        A table displaying panelists who have only appeared on the show one time along with their
                         total score and ranking.
                     </p>
                     <p>
@@ -477,7 +477,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of years with the aggregate panelist ranking and scoring statistics
+                        A table displaying years with the aggregate panelist ranking and scoring statistics
                         broken out by recorded panelist gender (based on how each panelist has
                         identified themselves).
                     </p>
@@ -491,7 +491,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists each with the number of appearances across regular shows,
+                        A table displaying panelists each with the number of appearances across regular shows,
                         all shows and shows with corresponding panelist scores, along with scoring
                         statistics.
                     </p>
@@ -509,7 +509,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of years each with the number of appearances across regular shows,
+                        A table displaying years each with the number of appearances across regular shows,
                         all shows and shows with corresponding panelist scores, along with scoring
                         statistics for a selected panelist.
                     </p>
@@ -527,8 +527,30 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of panelists with their longest string of appearances where they won
+                        A table displaying panelists with their longest string of appearances where they won
                         either by coming in first or tied for first.
+                    </p>
+                </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
+                    <a href="{{ url_for('panelists.wins_draws_losses') }}">
+                        Wins, Draws and Losses
+                    </a>
+                </h3>
+                <div class="description">
+                    <p>
+                        A table displaying panelists with the numbers of wins, draws, losses and
+                        total counts.
+                    </p>
+                    <p>
+                        In this report, a panelist finishing Lightning Fill-in-the-Blank in
+                        first place is a win, finishing tied for first place is a draw, and
+                        any other result is considered a loss.
+                    </p>
+                    <p>
+                        Appearances on and ranking from Best Of and repeat shows are not
+                        included.
                     </p>
                 </div>
             </li>

--- a/app/panelists/templates/panelists/appearance-counts-by-year-grid.html
+++ b/app/panelists/templates/panelists/appearance-counts-by-year-grid.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A large table displaying each panelist as rows and appearance counts for each
+        A table displaying each panelist as rows and appearance counts for each
         year as columns. Appearance counts includes regular shows and all shows, with
         the count of all shows in parentheses.
     </p>

--- a/app/panelists/templates/panelists/appearance-counts-by-year.html
+++ b/app/panelists/templates/panelists/appearance-counts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of panelist appearance counts for regular, Best Of,
+        A table displaying panelist appearance counts for regular, Best Of,
         repeat Best Ofs, repeat and all shows grouped by year.
     </p>
     <p>

--- a/app/panelists/templates/panelists/appearances-by-year.html
+++ b/app/panelists/templates/panelists/appearances-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of appearances with show information, including location, show
+        A table displaying appearances with show information, including location, show
         host, scorekeeper, other panelists and Not My Job guest(s), for a selected
         panelist grouped by year.
     </p>

--- a/app/panelists/templates/panelists/average-scores-by-year-all.html
+++ b/app/panelists/templates/panelists/average-scores-by-year-all.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A large table display each panelist as rows and average scores for each year as
+        A table displaying each panelist as rows and average scores for each year as
         columns.
     </p>
     <p>

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of average scores for a selected panelist broken out by year.
+        A table displaying average scores for a selected panelist broken out by year.
     </p>
     
     <p>

--- a/app/panelists/templates/panelists/bluff-the-listener-panelist-statistics-by-year.html
+++ b/app/panelists/templates/panelists/bluff-the-listener-panelist-statistics-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Bluff the Listener statistics, including the number of chosen stories,
+        A table displaying Bluff the Listener statistics, including the number of chosen stories,
         the number of correct stories, the number of regular Bluff the Listener
         segments, and the number of Unique Best Of Bluff the Listener segments, for a
         selected panelist, grouped by year.

--- a/app/panelists/templates/panelists/bluff-the-listener-statistics-by-year.html
+++ b/app/panelists/templates/panelists/bluff-the-listener-statistics-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Bluff the Listener statistics, including the number of chosen stories,
+        A table displaying Bluff the Listener statistics, including the number of chosen stories,
         the number of correct stories, the number of regular Bluff the Listener
         segments, and the number of Unique Best Of Bluff the Listener segments, for a
         selected year.

--- a/app/panelists/templates/panelists/bluff-the-listener-statistics.html
+++ b/app/panelists/templates/panelists/bluff-the-listener-statistics.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of Bluff the Listener statistics, including the number of chosen stories,
+        A table displaying Bluff the Listener statistics, including the number of chosen stories,
         the number of correct stories, the number of regular Bluff the Listener
         segments, and the number of Unique Best Of Bluff the Listener segments, for all
         panelists.

--- a/app/panelists/templates/panelists/debuts-by-year.html
+++ b/app/panelists/templates/panelists/debuts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of panelist debut appearances with show information, including
+        A table displaying panelist debut appearances with show information, including
         the number of regular show appearances, host, scorekeeper, Not My Job guest(s),
         grouped by year.
     </p>

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists who won outright or tied for first place on their debut
+        A table displaying panelists who won outright or tied for first place on their debut
         appearance. Information includes the show date, score at the start of the
         Lightning Fill-in-the-Blank round, the number of correct answers, total score,
         and ranking.

--- a/app/panelists/templates/panelists/first-appearances.html
+++ b/app/panelists/templates/panelists/first-appearances.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of the first appearance for all panelists, including their score
+        A table displaying the first appearance for all panelists, including their score
         at the start of the Lightning Fill-in-the-Blank round, the number of
         correct answers, total score, and ranking.
     </p>

--- a/app/panelists/templates/panelists/first-most-recent-appearances.html
+++ b/app/panelists/templates/panelists/first-most-recent-appearances.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with their first and most recent appearances for both
+        A table displaying panelists with their first and most recent appearances for both
         regular shows and for all shows (including Best Of and repeat shows) and the
         correponding number of appearances.
     </p>

--- a/app/panelists/templates/panelists/first-wins.html
+++ b/app/panelists/templates/panelists/first-wins.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the show they got their first outright win, by
+        A table displaying panelists with the show they got their first outright win, by
         finishing the Lightning Fill-in-the-Blank segment in first place, and
         their first overall win, which includes outright wins and finishing
         the segment tied for first.

--- a/app/panelists/templates/panelists/highest-average-correct-answers-by-year.html
+++ b/app/panelists/templates/panelists/highest-average-correct-answers-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with their average correct answers and number of appearances
+        A table displaying panelists with their average correct answers and number of appearances
         for a selected year. The list is sorted by average correct answers in descending
         order.
     </p>

--- a/app/panelists/templates/panelists/highest-average-scores-by-year.html
+++ b/app/panelists/templates/panelists/highest-average-scores-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with their average scores and number of appearances for a
+        A table displaying panelists with their average scores and number of appearances for a
         selected year. The list is sorted by average score in descending order.
     </p>
     <p>

--- a/app/panelists/templates/panelists/losing-streaks.html
+++ b/app/panelists/templates/panelists/losing-streaks.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with their longest string of appearances where they lost
+        A table displaying panelists with their longest string of appearances where they lost
         either by coming in tied for second or in third place, or losing outright by
         coming in third place.
     </p>

--- a/app/panelists/templates/panelists/most-chosen-bluff-the-listener-by-year.html
+++ b/app/panelists/templates/panelists/most-chosen-bluff-the-listener-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the number of times their Bluff the Listener story was
+        A table displaying panelists with the number of times their Bluff the Listener story was
         chosen for a selected year. The list is sorted by the counts in descending
         order.
     </p>

--- a/app/panelists/templates/panelists/most-chosen-correct-bluff-the-listener-by-year.html
+++ b/app/panelists/templates/panelists/most-chosen-correct-bluff-the-listener-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the number of times their Bluff the Listener story was
+        A table displaying panelists with the number of times their Bluff the Listener story was
         both chosen and was the correct story for a selected year. The list is sorted by
         the counts in descending order.
     </p>

--- a/app/panelists/templates/panelists/most-correct-bluff-the-listener-by-year.html
+++ b/app/panelists/templates/panelists/most-correct-bluff-the-listener-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the number of times their Bluff the Listener story was
+        A table displaying panelists with the number of times their Bluff the Listener story was
         the correct story for a selected year. The list is sorted by the counts in
         descending order.
     </p>

--- a/app/panelists/templates/panelists/most-wins-by-year.html
+++ b/app/panelists/templates/panelists/most-wins-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the number of times they have won outright, by coming in
+        A table displaying panelists with the number of times they have won outright, by coming in
         first place, or by coming either first place or tied for first place for a
         selected year.
     </p>

--- a/app/panelists/templates/panelists/panelist-vs-panelist-all.html
+++ b/app/panelists/templates/panelists/panelist-vs-panelist-all.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of comparisons of how well panelists performed against all other
+        A table displaying comparisons of how well panelists performed against all other
         panelists each have appeared with, grouped by panelist.
     </p>
     <p>

--- a/app/panelists/templates/panelists/perfect-score-counts.html
+++ b/app/panelists/templates/panelists/perfect-score-counts.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists who scored a total of 20 points, which Bill Kurtis calls
+        A table displaying panelists who scored a total of 20 points, which Bill Kurtis calls
         a "perfect score" with the number of times they have scored 20 points and the
         number of times they have scored 20 points or more.
     </p>

--- a/app/panelists/templates/panelists/rankings-summary.html
+++ b/app/panelists/templates/panelists/rankings-summary.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with the number of times each have finished the Lightning
+        A table displaying panelists with the number of times each have finished the Lightning
         Fill-in-the-Blank round in first, tied for first, second, tied for second, or
         third place, and a total count.
     </p>

--- a/app/panelists/templates/panelists/single-appearance.html
+++ b/app/panelists/templates/panelists/single-appearance.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists who have only appeared on the show one time along with their
+        A table displaying panelists who have only appeared on the show one time along with their
         total score and ranking.
     </p>
     <p>

--- a/app/panelists/templates/panelists/statistics-by-gender.html
+++ b/app/panelists/templates/panelists/statistics-by-gender.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of years with the aggregate panelist ranking and scoring statistics
+        A table displaying years with the aggregate panelist ranking and scoring statistics
         broken out by recorded panelist gender (based on how each panelist has
         identified themselves).
     </p>

--- a/app/panelists/templates/panelists/statistics-summary-by-year.html
+++ b/app/panelists/templates/panelists/statistics-summary-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of years each with the number of appearances across regular shows,
+        A table displaying years each with the number of appearances across regular shows,
         all shows and shows with corresponding panelist scores, along with scoring
         statistics for a selected panelist.
     </p>

--- a/app/panelists/templates/panelists/statistics-summary.html
+++ b/app/panelists/templates/panelists/statistics-summary.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists each with the number of appearances across regular shows,
+        A table displaying panelists each with the number of appearances across regular shows,
         all shows and shows with corresponding panelist scores, along with scoring
         statistics.
     </p>

--- a/app/panelists/templates/panelists/win-streaks.html
+++ b/app/panelists/templates/panelists/win-streaks.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% set page_title = "Win Streaks" %}
-{% block title %}Win Streaks | Panelists{% endblock %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of panelists with their longest string of appearances where they won
+        A table displaying panelists with their longest string of appearances where they won
         either by coming in first or tied for first.
     </p>
 </div>

--- a/app/panelists/templates/panelists/wins-draws-losses.html
+++ b/app/panelists/templates/panelists/wins-draws-losses.html
@@ -1,0 +1,265 @@
+{% extends "base.html" %}
+{% set page_title = "Wins, Draws and Losses" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        A table displaying panelists with the numbers of wins, draws, losses and
+        total counts.
+    </p>
+    <p>
+        In this report, a panelist finishing Lightning Fill-in-the-Blank in
+        first place is a win, finishing tied for first place is a draw, and
+        any other result is considered a loss.
+    </p>
+    <p>
+        Appearances on and ranking from Best Of and repeat shows are not
+        included.
+    </p>
+</div>
+
+<div class="card report-form mb-5">
+    <div class="card-body">
+        <form method="post" class="row row-cols-lg-auto g-3 align-items-center">
+            <div class="col-6">
+                <label for="sort-column">Sort Column</label>
+                <select id="sort-column" name="sort_column" class="form-select" aria-label="Sort column selection">
+                    <option value="">-- Select Column to Sort --</option>
+                    {% for column in table_columns %}
+                    {% if request.form.sort_column == column or sort_column == column %}
+                    <option value="{{ column }}" selected>{{ table_columns[column] }}</option>
+                    {% else %}
+                    <option value="{{ column }}">{{ table_columns[column] }}</option>
+                    {% endif %}
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-6">
+                <label for="minimum-total">Minimum Total Count</label>
+                <select id="minimum-total" name="minimum_total" class="form-select" aria-label="Minimum total count filter">
+                    <option value="">No Minimum</option>
+                    {% for min_value in minimum_values %}
+                    {% if request.form.minimum_total == min_value or minimum_total == min_value %}
+                    <option value="{{ min_value }}" selected>{{ min_value }}</option>
+                    {% else %}
+                    <option value="{{ min_value }}">{{ min_value }}</option>
+                    {% endif %}
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-auto">
+                <div class="form-check">
+                    <label for="sort-descending" class="form-check-label">Sort Descending</label>
+                    {% if request.form.sort_descending %}
+                    <input class="form-check-input" type="checkbox" id="sort-descending" name="sort_descending" checked>
+                    {% else %}
+                    <input class="form-check-input" type="checkbox" id="sort-descending" name="sort_descending">
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-6">
+                <input type="submit" class="btn btn-submit focus-ring" value="Submit">
+            </div>
+        </form>
+    </div>
+</div>
+
+{% if panelists %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="name">
+                    <col class="count long">
+                    <col class="count long">
+                    <col class="count long">
+                    <col class="count long">
+                    <col class="count long">
+                    <col class="count long">
+                    <col class="count long">
+                </colgroup>
+                <thead>
+                    <tr>
+                        {% for column in table_columns %}
+                        <th scope="col">
+                        {% if sort_column == column and sort_descending %}
+                            {{ table_columns[column] }} <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% elif sort_column == column and not sort_descending %}
+                            {{ table_columns[column] }} <i class="bi bi-sort-down-alt ps-1"><span class="d-none">Sort: Ascending</span></i>
+                        {% else %}
+                            {{ table_columns[column] }}
+                        {% endif %}
+                        </th>
+                        {% endfor %}
+                        {#
+                        <th scope="col">
+                        {% if sorted_by == "panelist" or sorted_by is none %}
+                            Panelist <i class="bi bi-sort-down-alt ps-1"><span class="d-none">Sort: Ascending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='panelist') }}">Panelist</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "wins" %}
+                            Wins <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='wins') }}">Wins</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "wins_percent" %}
+                            Wins % <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='wins_percent') }}">Wins %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "draws" %}
+                            Draws <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='draws') }}">Draws</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "draws_percent" %}
+                            Draws % <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='draws_percent') }}">Draws %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "losses" %}
+                            Losses <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='losses') }}">Losses</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "losses_percent" %}
+                            Losses % <i class="bi bi-sort-down ps-1"><span class="d-none">Sort: Descending</span></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='losses_percent') }}">Losses %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">Total</th>
+                        #}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for panelist in panelists %}
+                    {% set _panelist = panelists[panelist] %}
+                    <tr>
+                        <td><a href="{{ stats_url }}/panelists/{{ _panelist.slug }}">{{ _panelist.name }}</a></td>
+                        {% if _panelist.wins is not none %}
+                        <td>{{ _panelist.wins }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.wins_percent is not none %}
+                        <td>{{ "{:f}".format(_panelist.wins_percent.normalize()) }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.draws is not none %}
+                        <td>{{ _panelist.draws }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.draws_percent is not none %}
+                        <td>{{ "{:f}".format(_panelist.draws_percent.normalize()) }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.losses is not none %}
+                        <td>{{ _panelist.losses }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.losses_percent is not none %}
+                        <td>{{ "{:f}".format(_panelist.losses_percent.normalize()) }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if _panelist.total is not none %}
+                        <td>{{ _panelist.total }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col">
+                        {% if sorted_by == "panelist" or sorted_by is none %}
+                            Panelist <i class="bi bi-sort-down-alt ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='panelist') }}">Panelist</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "wins" %}
+                            Wins <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='wins') }}">Wins</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "wins_percent" %}
+                            Wins % <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='wins_percent') }}">Wins %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "draws" %}
+                            Draws <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='draws') }}">Draws</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "draws_percent" %}
+                            Draws % <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='draws_percent') }}">Draws %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "losses" %}
+                            Losses <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='losses') }}">Losses</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">
+                        {% if sorted_by == "losses_percent" %}
+                            Losses % <i class="bi bi-sort-down ps-1"></i>
+                        {% else %}
+                            <a href="{{ url_for('panelists.wins_draws_losses', sort='losses_percent') }}">Losses %</a>
+                        {% endif %}
+                        </th>
+                        <th scope="col">Total</th>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/scorekeepers/templates/scorekeepers/_index.html
+++ b/app/scorekeepers/templates/scorekeepers/_index.html
@@ -26,7 +26,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of scorekeeper appearance counts for regular, Best Of,
+                        A table displaying scorekeeper appearance counts for regular, Best Of,
                         repeat Best Ofs, repeat and all shows grouped by year.
                     </p>
                     <p>
@@ -45,7 +45,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A large table displaying each scorekeeper as rows and appearance counts
+                        A table displaying each scorekeeper as rows and appearance counts
                         for each year as columns. Scorekeeper appearance counts includes regular shows
                         and all shows, with the count of all shows in parentheses.
                     </p>
@@ -63,7 +63,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of scorekeepers with their first and most recent appearances and
+                        A table displaying scorekeepers with their first and most recent appearances and
                         corresponding count of appearances for both regular shows and all shows.
                     </p>
                     <p>
@@ -80,7 +80,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of appearances with show information, including location,
+                        A table displaying appearances with show information, including location,
                         host, panelists and Not My Job guest(s), for a selected scorekeeper grouped by
                         year.
                     </p>
@@ -94,7 +94,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of scorekeeper debut appearances with show information, including
+                        A table displaying scorekeeper debut appearances with show information, including
                         location, host, panelists and Not My Job guest(s), grouped by year.
                     </p>
                 </div>
@@ -107,7 +107,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A collection of scorekeepers with a list of introductions that they have used
+                        A table displaying scorekeepers with A table displaying introductions that they have used
                         at the start of each show they appeared on.
                     </p>
                 </div>

--- a/app/scorekeepers/templates/scorekeepers/appearance-counts-by-year-grid.html
+++ b/app/scorekeepers/templates/scorekeepers/appearance-counts-by-year-grid.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A large table displaying each scorekeeper as rows and appearance counts
+        A table displaying each scorekeeper as rows and appearance counts
         for each year as columns. Scorekeeper appearance counts includes regular shows
         and all shows, with the count of all shows in parentheses.
     </p>

--- a/app/scorekeepers/templates/scorekeepers/appearance-counts-by-year.html
+++ b/app/scorekeepers/templates/scorekeepers/appearance-counts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of scorekeeper appearance counts for regular, Best Of,
+        A table displaying scorekeeper appearance counts for regular, Best Of,
         repeat Best Ofs, repeat and all shows grouped by year.
     </p>
     <p>

--- a/app/scorekeepers/templates/scorekeepers/appearance-summary.html
+++ b/app/scorekeepers/templates/scorekeepers/appearance-summary.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of scorekeepers with their first and most recent appearances and
+        A table displaying scorekeepers with their first and most recent appearances and
         corresponding count of appearances for both regular shows and all shows.
     </p>
     <p>

--- a/app/scorekeepers/templates/scorekeepers/appearances-by-year.html
+++ b/app/scorekeepers/templates/scorekeepers/appearances-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of appearances with show information, including location,
+        A table displaying appearances with show information, including location,
         host, panelists and Not My Job guest(s), for a selected scorekeeper grouped by
         year.
     </p>

--- a/app/scorekeepers/templates/scorekeepers/debuts-by-year.html
+++ b/app/scorekeepers/templates/scorekeepers/debuts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of scorekeeper debut appearances with show information, including
+        A table displaying scorekeeper debut appearances with show information, including
         location, host, panelists and Not My Job guest(s), grouped by year.
     </p>
 </div>

--- a/app/scorekeepers/templates/scorekeepers/scorekeeper-introductions.html
+++ b/app/scorekeepers/templates/scorekeepers/scorekeeper-introductions.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A collection of scorekeepers with a list of introductions that they have used
+        A table displaying scorekeepers with A table displaying introductions that they have used
         at the start of each show they appeared on.
     </p>
 </div>

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -25,7 +25,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows that have been broadcasted, including Best Of and repeat
+                        A table displaying all shows that have been broadcasted, including Best Of and repeat
                         shows. The list does not include any pledge specials shows or special
                         shows that were not aired in their original form.
                     </p>
@@ -39,7 +39,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows that have had an all women panel.
+                        A table displaying shows that have had an all women panel.
                     </p>
                 </div>
             </li>
@@ -51,7 +51,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all Best Of shows that have been broadcasted. The list does not
+                        A table displaying all Best Of shows that have been broadcasted. The list does not
                         include any pledge specials shows or special shows that were not aired in their
                         original form.
                     </p>
@@ -65,7 +65,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where the total score for all three panelists is greater than
+                        A table displaying shows where the total score for all three panelists is greater than
                         or equal to 50. The shows are sorted by total score in descending order.
                     </p>
                     <p>
@@ -81,7 +81,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where the highest panelist total score is equal to the sum of
+                        A table displaying shows where the highest panelist total score is equal to the sum of
                         the two other panelists' total scores.
                     </p>
                     <p>
@@ -97,7 +97,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where all three panelists answered the same number of Lightning
+                        A table displaying shows where all three panelists answered the same number of Lightning
                         Fill-in-the-Blank questions correct.
                     </p>
                     <p>
@@ -113,7 +113,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where all three panelists finished the Lightning
+                        A table displaying shows where all three panelists finished the Lightning
                         Fill-in-the-Blank segment in a three-way tie.
                     </p>
                     <p>
@@ -129,7 +129,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where all three panelists started <em>and</em> finished the
+                        A table displaying shows where all three panelists started <em>and</em> finished the
                         Lightning Fill-in-the-Blank segment in a three-way tie.
                     </p>
                     <p>
@@ -145,7 +145,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where all three panelists started the Lightning
+                        A table displaying shows where all three panelists started the Lightning
                         Fill-in-the-Blank segment in a three-way tie.
                     </p>
                     <p>
@@ -161,7 +161,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where a panelist started the Lightning Fill-in-the Blank segment
+                        A table displaying shows where a panelist started the Lightning Fill-in-the Blank segment
                         with zero points.
                     </p>
                     <p>
@@ -177,7 +177,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where a panelist did not answer any Lightning Fill-in-the-Blank
+                        A table displaying shows where a panelist did not answer any Lightning Fill-in-the-Blank
                         questions correct, thus netting zero additional points.
                     </p>
                     <p>
@@ -193,7 +193,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where the total score for all three panelists is less than 30.
+                        A table displaying shows where the total score for all three panelists is less than 30.
                         The shows are sorted by total score in descending order.
                     </p>
                     <p>
@@ -242,7 +242,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all original (generally labeled as regular) shows that have been
+                        A table displaying all original (generally labeled as regular) shows that have been
                         broadcasted. The list does not Best Of, repeat, or any pledge specials shows
                         or special shows that were not aired in their original form.
                     </p>
@@ -256,7 +256,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of years with the number of times a show has had different combination
+                        A table displaying years with the number of times a show has had different combination
                         of men and women on a panel, including any instances of an all men or an all
                         women panel.
                     </p>
@@ -276,7 +276,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all repeat Best Of shows that have been broadcasted. The list does not
+                        A table displaying all repeat Best Of shows that have been broadcasted. The list does not
                         include any pledge specials shows or special shows that were not aired in their
                         original form.
                     </p>
@@ -290,7 +290,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all repeat shows that have been broadcasted. The list does not include
+                        A table displaying all repeat shows that have been broadcasted. The list does not include
                         any pledge specials shows or special shows that were not aired in their original
                         form.
                     </p>
@@ -304,7 +304,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where up to three selected panelists have appeared on the same
+                        A table displaying shows where up to three selected panelists have appeared on the same
                         panel. Options are available to include Best Of and/or repeats shows.
                     </p>
                     <p>
@@ -321,7 +321,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of years with corresponding number of regular shows, Best Of shows,
+                        A table displaying years with corresponding number of regular shows, Best Of shows,
                         repeat shows, repeat Best Of shows, and a total number of shows for each year.
                     </p>
                     <p>
@@ -337,7 +337,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows with the corresponding show descriptions.
+                        A table displaying all shows with the corresponding show descriptions.
                     </p>
                 </div>
             </li>
@@ -349,7 +349,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows with the corresponding show notes.
+                        A table displaying all shows with the corresponding show notes.
                     </p>
                 </div>
             </li>
@@ -361,7 +361,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows, including Best Of and repeat shows, that have had a guest
+                        A table displaying all shows, including Best Of and repeat shows, that have had a guest
                         host.
                     </p>
                 </div>
@@ -374,7 +374,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows, including Best Of and repeat shows, that have had a guest
+                        A table displaying all shows, including Best Of and repeat shows, that have had a guest
                         host and a guest scorekeeper.
                     </p>
                 </div>
@@ -387,7 +387,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of all shows, including Best Of and repeat shows, that have had a guest
+                        A table displaying all shows, including Best Of and repeat shows, that have had a guest
                         scorekeeper.
                     </p>
                 </div>
@@ -400,7 +400,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A list of shows where a panelist finishes the Lightning Fill-in-the-Blank
+                        A table displaying shows where a panelist finishes the Lightning Fill-in-the-Blank
                         segment with a total score of 20 points, a "perfect score" according to
                         scorekeeper Bill Kurtis.
                     </p>

--- a/app/shows/templates/shows/all-shows.html
+++ b/app/shows/templates/shows/all-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows that have been broadcasted, including Best Of and repeat
+        A table displaying all shows that have been broadcasted, including Best Of and repeat
         shows. The list does not include any pledge specials shows or special
         shows that were not aired in their original form.
     </p>

--- a/app/shows/templates/shows/all-women-panel.html
+++ b/app/shows/templates/shows/all-women-panel.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows that have had an all women panel.
+        A table displaying shows that have had an all women panel.
     </p>
 </div>
 

--- a/app/shows/templates/shows/best-of-shows.html
+++ b/app/shows/templates/shows/best-of-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all Best Of shows that have been broadcasted. The list does not
+        A table displaying all Best Of shows that have been broadcasted. The list does not
         include any pledge specials shows or special shows that were not aired in their
         original form.
     </p>

--- a/app/shows/templates/shows/high-scoring-shows.html
+++ b/app/shows/templates/shows/high-scoring-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where the total score for all three panelists is greater than
+        A table displaying shows where the total score for all three panelists is greater than
         or equal to 50. The shows are sorted by total score in descending order.
     </p>
     <p>

--- a/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
+++ b/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where the highest panelist total score is equal to the sum of
+        A table displaying shows where the highest panelist total score is equal to the sum of
         the two other panelists' total scores.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where all three panelists answered the same number of Lightning
+        A table displaying shows where all three panelists answered the same number of Lightning
         Fill-in-the-Blank questions correct.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where all three panelists finished the Lightning
+        A table displaying shows where all three panelists finished the Lightning
         Fill-in-the-Blank segment in a three-way tie.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where all three panelists started <em>and</em> finished the
+        A table displaying shows where all three panelists started <em>and</em> finished the
         Lightning Fill-in-the-Blank segment in a three-way tie.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where all three panelists started the Lightning
+        A table displaying shows where all three panelists started the Lightning
         Fill-in-the-Blank segment in a three-way tie.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-starting-zero-points.html
+++ b/app/shows/templates/shows/lightning-round-starting-zero-points.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where a panelist started the Lightning Fill-in-the Blank segment
+        A table displaying shows where a panelist started the Lightning Fill-in-the Blank segment
         with zero points.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where a panelist did not answer any Lightning Fill-in-the-Blank
+        A table displaying shows where a panelist did not answer any Lightning Fill-in-the-Blank
         questions correct, thus netting zero additional points.
     </p>
     <p>

--- a/app/shows/templates/shows/low-scoring-shows.html
+++ b/app/shows/templates/shows/low-scoring-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where the total score for all three panelists is less than 30.
+        A table displaying shows where the total score for all three panelists is less than 30.
         The shows are sorted by total score in descending order.
     </p>
     <p>

--- a/app/shows/templates/shows/original-shows.html
+++ b/app/shows/templates/shows/original-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all original (generally labeled as regular) shows that have been
+        A table displaying all original (generally labeled as regular) shows that have been
         broadcasted. The list does not Best Of, repeat, or any pledge specials shows
         or special shows that were not aired in their original form.
     </p>

--- a/app/shows/templates/shows/panel-gender-mix.html
+++ b/app/shows/templates/shows/panel-gender-mix.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of years with the number of times a show has had different combination
+        A table displaying years with the number of times a show has had different combination
         of men and women on a panel, including any instances of an all men or an all
         women panel.
     </p>

--- a/app/shows/templates/shows/repeat-best-of-shows.html
+++ b/app/shows/templates/shows/repeat-best-of-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all repeat Best Of shows that have been broadcasted. The list does not
+        A table displaying all repeat Best Of shows that have been broadcasted. The list does not
         include any pledge specials shows or special shows that were not aired in their
         original form.
     </p>

--- a/app/shows/templates/shows/repeat-shows.html
+++ b/app/shows/templates/shows/repeat-shows.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all repeat shows that have been broadcasted. The list does not include
+        A table displaying all repeat shows that have been broadcasted. The list does not include
         any pledge specials shows or special shows that were not aired in their original
         form.
     </p>

--- a/app/shows/templates/shows/search-shows-by-multiple-panelists.html
+++ b/app/shows/templates/shows/search-shows-by-multiple-panelists.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where up to three selected panelists have appeared on the same
+        A table displaying shows where up to three selected panelists have appeared on the same
         panel. Options are available to include Best Of and/or repeats shows.
     </p>
     <p>

--- a/app/shows/templates/shows/show-counts-by-year.html
+++ b/app/shows/templates/shows/show-counts-by-year.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of years with corresponding number of regular shows, Best Of shows,
+        A table displaying years with corresponding number of regular shows, Best Of shows,
         repeat shows, repeat Best Of shows, and a total number of shows for each year.
     </p>
     <p>

--- a/app/shows/templates/shows/show-descriptions.html
+++ b/app/shows/templates/shows/show-descriptions.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows with the corresponding show descriptions.
+        A table displaying all shows with the corresponding show descriptions.
     </p>
 </div>
 

--- a/app/shows/templates/shows/show-notes.html
+++ b/app/shows/templates/shows/show-notes.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows with the corresponding show notes.
+        A table displaying all shows with the corresponding show notes.
     </p>
 </div>
 

--- a/app/shows/templates/shows/shows-with-guest-host-scorekeeper.html
+++ b/app/shows/templates/shows/shows-with-guest-host-scorekeeper.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows, including Best Of and repeat shows, that have had a guest
+        A table displaying all shows, including Best Of and repeat shows, that have had a guest
         host and a guest scorekeeper.
     </p>
 </div>

--- a/app/shows/templates/shows/shows-with-guest-host.html
+++ b/app/shows/templates/shows/shows-with-guest-host.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows, including Best Of and repeat shows, that have had a guest
+        A table displaying all shows, including Best Of and repeat shows, that have had a guest
         host.
     </p>
 </div>

--- a/app/shows/templates/shows/shows-with-guest-scorekeeper.html
+++ b/app/shows/templates/shows/shows-with-guest-scorekeeper.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of all shows, including Best Of and repeat shows, that have had a guest
+        A table displaying all shows, including Best Of and repeat shows, that have had a guest
         scorekeeper.
     </p>
 </div>

--- a/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
+++ b/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A list of shows where a panelist finishes the Lightning Fill-in-the-Blank
+        A table displaying shows where a panelist finishes the Lightning Fill-in-the-Blank
         segment with a total score of 20 points, a "perfect score" according to
         scorekeeper Bill Kurtis.
     </p>

--- a/app/sitemaps/templates/sitemaps/panelists.xml
+++ b/app/sitemaps/templates/sitemaps/panelists.xml
@@ -124,4 +124,8 @@
     <loc>{{ site_url }}{{ url_for("panelists.win_streaks") }}</loc>
     <changefreq>weekly</changefreq>
   </url>
+  <url>
+    <loc>{{ site_url }}{{ url_for("panelists.wins_draws_losses") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.2.1"
+APP_VERSION = "4.3.0"

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -486,3 +486,34 @@ def test_win_streaks(client: FlaskClient) -> None:
     assert b"Win Streaks" in response.data
     assert b"Outright Wins" in response.data
     assert b"Wins with Draws" in response.data
+
+
+def test_wins_draws_losses(client: FlaskClient) -> None:
+    """Testing panelists.routes.wins_draws_losses."""
+    response: TestResponse = client.get("/panelists/wins-draws-losses")
+    assert response.status_code == 200
+    assert b"Wins, Draws and Losses" in response.data
+    assert b"Sort Column" in response.data
+    assert b"<table" in response.data
+
+
+@pytest.mark.parametrize(
+    "minimum_total, sort_column, sort_descending",
+    [(0, "", False), (0, "", True), (5, "panelist", False), (5, "panelist", True)],
+)
+def test_wins_draws_losses_post(
+    client: FlaskClient, minimum_total: int, sort_column: str, sort_descending: bool
+) -> None:
+    """Testing panelists.routes.wins_draws_losses (POST)."""
+    response: TestResponse = client.post(
+        "/panelists/wins-draws-losses",
+        data={
+            "minimum_total": minimum_total,
+            "sort_column": sort_column,
+            "sort_descending": sort_descending,
+        },
+    )
+    assert response.status_code == 200
+    assert b"Wins, Draws and Losses" in response.data
+    assert b"Sort Column" in response.data
+    assert b"<table" in response.data


### PR DESCRIPTION
## Application Changes

- Adding new Panelists "Wins, Draws and Losses" report that includes the number of times a panelist finished in first place (win), finished tied for first (draw), or lost (all other positions)
- Reworded the beginning of report descriptions for more consistency