### PR TITLE
Standardize on "Lightning Fill In The Blank" segment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 4.3.3
+
+### Application Changes
+
+- Standardized on the name "Lightning Fill In The Blank" for the segment, including:
+  - Replaced all references of "Lightning Round" in report titles with "Lightning Fill In The Blank Segment"
+  - Replaced "Fill-in-the-Blank" with "Fill In The Blank"
+  - This does not change the name of the functions or variables
+
 ## 4.3.2
 
 ### Application Changes

--- a/app/locations/templates/locations/_index.html
+++ b/app/locations/templates/locations/_index.html
@@ -33,7 +33,7 @@
                     <p>
                         Panelist scores from the 20th anniversary special show, that aired on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>, are
-                        omitted due to the unique Lightning Fill-in-the-Blank format used for
+                        omitted due to the unique Lightning Fill In The Blank format used for
                         that show.
                     </p>
                 </div>

--- a/app/locations/templates/locations/average-scores-by-location.html
+++ b/app/locations/templates/locations/average-scores-by-location.html
@@ -20,7 +20,7 @@
     <p>
         Panelist scores from the 20th anniversary special show, that aired on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>, are
-        omitted due to the unique Lightning Fill-in-the-Blank format used for
+        omitted due to the unique Lightning Fill In The Blank format used for
         that show.
     </p>
 </div>

--- a/app/panelists/templates/panelists/_index.html
+++ b/app/panelists/templates/panelists/_index.html
@@ -210,7 +210,7 @@
                     <p>
                         A table displaying panelists who won outright or tied for first place on their debut
                         appearance. Information includes the show date, score at the start of the
-                        Lightning Fill In The Blank round, the number of correct answers, total score,
+                        Lightning Fill In The Blank Segment, the number of correct answers, total score,
                         and ranking.
                     </p>
                 </div>
@@ -224,7 +224,7 @@
                 <div class="description">
                     <p>
                         A table displaying the first appearance for all panelists, including their score
-                        at the start of the Lightning Fill In The Blank round, the number of
+                        at the start of the Lightning Fill In The Blank Segment, the number of
                         correct answers, total score, and ranking.
                     </p>
                 </div>
@@ -445,7 +445,7 @@
                 <div class="description">
                     <p>
                         A table displaying panelists with the number of times each have finished the Lightning
-                        Fill In The Blank round in first, tied for first, second, tied for second, or
+                        Fill In The Blank Segment in first, tied for first, second, tied for second, or
                         third place, and a total count.
                     </p>
                     <p>

--- a/app/panelists/templates/panelists/_index.html
+++ b/app/panelists/templates/panelists/_index.html
@@ -103,7 +103,7 @@
                         average. Additionally, panelist scores from the 29th anniversary show that aired
                         on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> show are also
-                        excluded, due to the unique Lightning Fill-in-the-Blank format.
+                        excluded, due to the unique Lightning Fill In The Blank format.
                     </p>
                 </div>
             </li>
@@ -123,7 +123,7 @@
                         average. Additionally, panelist scores from the 29th anniversary show that aired
                         on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> show are also
-                        excluded, due to the unique Lightning Fill-in-the-Blank format.
+                        excluded, due to the unique Lightning Fill In The Blank format.
                     </p>
                 </div>
             </li>
@@ -210,7 +210,7 @@
                     <p>
                         A table displaying panelists who won outright or tied for first place on their debut
                         appearance. Information includes the show date, score at the start of the
-                        Lightning Fill-in-the-Blank round, the number of correct answers, total score,
+                        Lightning Fill In The Blank round, the number of correct answers, total score,
                         and ranking.
                     </p>
                 </div>
@@ -224,7 +224,7 @@
                 <div class="description">
                     <p>
                         A table displaying the first appearance for all panelists, including their score
-                        at the start of the Lightning Fill-in-the-Blank round, the number of
+                        at the start of the Lightning Fill In The Blank round, the number of
                         correct answers, total score, and ranking.
                     </p>
                 </div>
@@ -235,7 +235,7 @@
                 </h3>
                 <p>
                     A table displaying panelists with the show they got their first outright win, by
-                    finishing the Lightning Fill-in-the-Blank segment in first place, and
+                    finishing the Lightning Fill In The Blank segment in first place, and
                     their first overall win, which includes outright wins and finishing
                     the segment tied for first.
                 </p>
@@ -260,7 +260,7 @@
                         Scoring information excludes Best Of and repeat shows, as well as the 20th
                         anniversary show that aired on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>
-                        due to the unique Lightning Fill-in-the-Blank format.
+                        due to the unique Lightning Fill In The Blank format.
                     </p>
                 </div>
             </li>
@@ -279,7 +279,7 @@
                         Scoring information excludes Best Of and repeat shows, as well as the 20th
                         anniversary show that aired on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>
-                        due to the unique Lightning Fill-in-the-Blank format.
+                        due to the unique Lightning Fill In The Blank format.
                     </p>
                 </div>
             </li>
@@ -445,7 +445,7 @@
                 <div class="description">
                     <p>
                         A table displaying panelists with the number of times each have finished the Lightning
-                        Fill-in-the-Blank round in first, tied for first, second, tied for second, or
+                        Fill In The Blank round in first, tied for first, second, tied for second, or
                         third place, and a total count.
                     </p>
                     <p>
@@ -544,7 +544,7 @@
                         total counts.
                     </p>
                     <p>
-                        In this report, a panelist finishing Lightning Fill-in-the-Blank in
+                        In this report, a panelist finishing Lightning Fill In The Blank in
                         first place is a win, finishing tied for first place is a draw, and
                         any other result is considered a loss.
                     </p>

--- a/app/panelists/templates/panelists/_index.html
+++ b/app/panelists/templates/panelists/_index.html
@@ -210,7 +210,7 @@
                     <p>
                         A table displaying panelists who won outright or tied for first place on their debut
                         appearance. Information includes the show date, score at the start of the
-                        Lightning Fill In The Blank Segment, the number of correct answers, total score,
+                        Lightning Fill In The Blank segment, the number of correct answers, total score,
                         and ranking.
                     </p>
                 </div>
@@ -224,7 +224,7 @@
                 <div class="description">
                     <p>
                         A table displaying the first appearance for all panelists, including their score
-                        at the start of the Lightning Fill In The Blank Segment, the number of
+                        at the start of the Lightning Fill In The Blank segment, the number of
                         correct answers, total score, and ranking.
                     </p>
                 </div>
@@ -445,7 +445,7 @@
                 <div class="description">
                     <p>
                         A table displaying panelists with the number of times each have finished the Lightning
-                        Fill In The Blank Segment in first, tied for first, second, tied for second, or
+                        Fill In The Blank segment in first, tied for first, second, tied for second, or
                         third place, and a total count.
                     </p>
                     <p>

--- a/app/panelists/templates/panelists/average-scores-by-year-all.html
+++ b/app/panelists/templates/panelists/average-scores-by-year-all.html
@@ -21,7 +21,7 @@
         average. Additionally, panelist scores from the 29th anniversary show that aired
         on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> show are also
-        excluded, due to the unique Lightning Fill-in-the-Blank format.
+        excluded, due to the unique Lightning Fill In The Blank format.
     </p>
 </div>
 

--- a/app/panelists/templates/panelists/average-scores-by-year.html
+++ b/app/panelists/templates/panelists/average-scores-by-year.html
@@ -21,7 +21,7 @@
         average. Additionally, panelist scores from the 29th anniversary show that aired
         on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> show are also
-        excluded, due to the unique Lightning Fill-in-the-Blank format.
+        excluded, due to the unique Lightning Fill In The Blank format.
     </p>
 </div>
 

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -15,7 +15,7 @@
     <p>
         A table displaying panelists who won outright or tied for first place on their debut
         appearance. Information includes the show date, score at the start of the
-        Lightning Fill In The Blank round, the number of correct answers, total score,
+        Lightning Fill In The Blank Segment, the number of correct answers, total score,
         and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -15,7 +15,7 @@
     <p>
         A table displaying panelists who won outright or tied for first place on their debut
         appearance. Information includes the show date, score at the start of the
-        Lightning Fill-in-the-Blank round, the number of correct answers, total score,
+        Lightning Fill In The Blank round, the number of correct answers, total score,
         and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-appearance-wins.html
+++ b/app/panelists/templates/panelists/first-appearance-wins.html
@@ -15,7 +15,7 @@
     <p>
         A table displaying panelists who won outright or tied for first place on their debut
         appearance. Information includes the show date, score at the start of the
-        Lightning Fill In The Blank Segment, the number of correct answers, total score,
+        Lightning Fill In The Blank segment, the number of correct answers, total score,
         and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-appearances.html
+++ b/app/panelists/templates/panelists/first-appearances.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying the first appearance for all panelists, including their score
-        at the start of the Lightning Fill-in-the-Blank round, the number of
+        at the start of the Lightning Fill In The Blank round, the number of
         correct answers, total score, and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-appearances.html
+++ b/app/panelists/templates/panelists/first-appearances.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying the first appearance for all panelists, including their score
-        at the start of the Lightning Fill In The Blank Segment, the number of
+        at the start of the Lightning Fill In The Blank segment, the number of
         correct answers, total score, and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-appearances.html
+++ b/app/panelists/templates/panelists/first-appearances.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying the first appearance for all panelists, including their score
-        at the start of the Lightning Fill In The Blank round, the number of
+        at the start of the Lightning Fill In The Blank Segment, the number of
         correct answers, total score, and ranking.
     </p>
 </div>

--- a/app/panelists/templates/panelists/first-wins.html
+++ b/app/panelists/templates/panelists/first-wins.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying panelists with the show they got their first outright win, by
-        finishing the Lightning Fill-in-the-Blank segment in first place, and
+        finishing the Lightning Fill In The Blank segment in first place, and
         their first overall win, which includes outright wins and finishing
         the segment tied for first.
     </p>

--- a/app/panelists/templates/panelists/highest-average-correct-answers-by-year.html
+++ b/app/panelists/templates/panelists/highest-average-correct-answers-by-year.html
@@ -21,7 +21,7 @@
         Scoring information excludes Best Of and repeat shows, as well as the 20th
         anniversary show that aired on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>
-        due to the unique Lightning Fill-in-the-Blank format.
+        due to the unique Lightning Fill In The Blank format.
     </p>
 </div>
 

--- a/app/panelists/templates/panelists/highest-average-scores-by-year.html
+++ b/app/panelists/templates/panelists/highest-average-scores-by-year.html
@@ -20,7 +20,7 @@
         Scoring information excludes Best Of and repeat shows, as well as the 20th
         anniversary show that aired on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a>
-        due to the unique Lightning Fill-in-the-Blank format.
+        due to the unique Lightning Fill In The Blank format.
     </p>
 </div>
 

--- a/app/panelists/templates/panelists/rankings-summary.html
+++ b/app/panelists/templates/panelists/rankings-summary.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying panelists with the number of times each have finished the Lightning
-        Fill-in-the-Blank round in first, tied for first, second, tied for second, or
+        Fill In The Blank round in first, tied for first, second, tied for second, or
         third place, and a total count.
     </p>
     <p>

--- a/app/panelists/templates/panelists/rankings-summary.html
+++ b/app/panelists/templates/panelists/rankings-summary.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying panelists with the number of times each have finished the Lightning
-        Fill In The Blank round in first, tied for first, second, tied for second, or
+        Fill In The Blank Segment in first, tied for first, second, tied for second, or
         third place, and a total count.
     </p>
     <p>

--- a/app/panelists/templates/panelists/rankings-summary.html
+++ b/app/panelists/templates/panelists/rankings-summary.html
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying panelists with the number of times each have finished the Lightning
-        Fill In The Blank Segment in first, tied for first, second, tied for second, or
+        Fill In The Blank segment in first, tied for first, second, tied for second, or
         third place, and a total count.
     </p>
     <p>

--- a/app/panelists/templates/panelists/wins-draws-losses.html
+++ b/app/panelists/templates/panelists/wins-draws-losses.html
@@ -17,7 +17,7 @@
         total counts.
     </p>
     <p>
-        In this report, a panelist finishing Lightning Fill-in-the-Blank in
+        In this report, a panelist finishing Lightning Fill In The Blank in
         first place is a win, finishing tied for first place is a draw, and
         any other result is considered a loss.
     </p>

--- a/app/shows/redirects.py
+++ b/app/shows/redirects.py
@@ -86,7 +86,7 @@ def highest_score_equals_sum_other_scores() -> Response:
 
 @blueprint.route("/show/lightning_round_end_three_way_tie")
 def lightning_round_ending_three_way_tie() -> Response:
-    """View: Lightning Round Ending in a Three-Way Tie Report Redirect."""
+    """View: Lightning Fill In The Blank Ending in a Three-Way Tie Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_ending_three_way_tie"), status_code=301
     )
@@ -94,7 +94,7 @@ def lightning_round_ending_three_way_tie() -> Response:
 
 @blueprint.route("/show/lightning_round_start_end_three_way_tie")
 def lightning_round_start_ending_three_way_tie() -> Response:
-    """View: Lightning Round Starting and Ending in a Three-Way Tie Report Redirect."""
+    """View: Lightning Fill In The Blank Starting and Ending in a Three-Way Tie Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_starting_ending_three_way_tie"), status_code=301
     )
@@ -102,7 +102,7 @@ def lightning_round_start_ending_three_way_tie() -> Response:
 
 @blueprint.route("/show/lighting_round_start_zero")
 def lightning_round_starting_zero_points() -> Response:
-    """View: Lightning Round Starting with Zero Points Report Redirect."""
+    """View: Lightning Fill In The Blank Starting with Zero Points Report Redirect."""
     return redirect_url(
         url_for("shows.lightning_round_starting_zero_points"), status_code=301
     )
@@ -110,7 +110,7 @@ def lightning_round_starting_zero_points() -> Response:
 
 @blueprint.route("/show/lightning_round_zero_correct")
 def lightning_round_zero_correct():
-    """View: Lightning Round with Zero Correct Answers Report Redirect."""
+    """View: Lightning Fill In The Blank with Zero Correct Answers Report Redirect."""
     return redirect_url(url_for("shows.lightning_round_zero_correct"), status_code=301)
 
 

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -57,11 +57,11 @@ def retrieve_scoring_info_by_show_id(
     show_id: int,
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
-    """Return Lightning Fill-in-the-Blank round scoring information.
+    """Return Lightning Fill-in-the-Blank segment scoring information.
 
     Returned information includes starting points, number of correct
     answers and final score for the requested show ID. Used for
-    getting scoring details where the round starts in a three-way tie.
+    getting scoring details where the segment starts in a three-way tie.
     """
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -131,7 +131,7 @@ def retrieve_panelists_by_show_id(
 def shows_with_lightning_round_start_zero(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Return shows in which panelists start the Lightning round with zero points."""
+    """Return shows in which panelists start Lightning Fill In The Blank with zero points."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 
@@ -177,7 +177,7 @@ def shows_with_lightning_round_start_zero(
 def shows_lightning_round_start_zero(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Return list of shows in which a panelist starts the Lightning round with zero points."""
+    """Return list of shows in which a panelist starts the Lightning Fill In The Blank with zero points."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 
@@ -222,7 +222,7 @@ def shows_lightning_round_start_zero(
 def shows_lightning_round_zero_correct(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Return list of shows in which a panelist answers zero Lightning round questions correct."""
+    """Return list of shows in which a panelist answers zero Lightning Fill In The Blank questions correct."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 
@@ -314,7 +314,7 @@ def shows_lightning_round_answering_same_number_correct(
 def shows_starting_with_three_way_tie(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Retrieve all shows in which all three panelists started the Lightning round in a three-way tie."""
+    """Retrieve all shows in which all three panelists started the Lightning Fill In The Blank in a three-way tie."""
     show_scores = retrieve_all_lightning_round_start(
         database_connection=database_connection,
     )
@@ -342,7 +342,7 @@ def shows_starting_with_three_way_tie(
 def shows_ending_with_three_way_tie(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Retrieve all shows in which all three panelists ended the Lightning round in a three-way tie."""
+    """Retrieve all shows in which all three panelists ended the Lightning Fill In The Blank in a three-way tie."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 
@@ -385,7 +385,7 @@ def shows_ending_with_three_way_tie(
 def shows_starting_ending_three_way_tie(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:
-    """Retrieve all shows in which all three panelists started and ended the Lightning round in a three-way tie."""
+    """Retrieve all shows in which all three panelists started and ended the Lightning Fill In The Blank in a three-way tie."""
     start_tie = shows_starting_with_three_way_tie(database_connection)
     end_tie = shows_ending_with_three_way_tie(
         database_connection=database_connection,

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -13,7 +13,7 @@ from mysql.connector.pooling import PooledMySQLConnection
 def retrieve_all_lightning_round_start(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
-    """Retrieve a dictionary of all Lightning Fill In The Blank Segment starting scores."""
+    """Retrieve a dictionary of all Lightning Fill In The Blank segment starting scores."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -4,7 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=C0301
-"""WWDTM Lightning Fill-in-the-Blank Segment Report Functions."""
+"""WWDTM Lightning Fill In The Blank Segment Report Functions."""
 
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
@@ -13,7 +13,7 @@ from mysql.connector.pooling import PooledMySQLConnection
 def retrieve_all_lightning_round_start(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
-    """Retrieve a dictionary of all Lightning Fill-in-the-Blank round starting scores."""
+    """Retrieve a dictionary of all Lightning Fill In The Blank round starting scores."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 
@@ -57,7 +57,7 @@ def retrieve_scoring_info_by_show_id(
     show_id: int,
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
-    """Return Lightning Fill-in-the-Blank segment scoring information.
+    """Return Lightning Fill In The Blank segment scoring information.
 
     Returned information includes starting points, number of correct
     answers and final score for the requested show ID. Used for

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -13,7 +13,7 @@ from mysql.connector.pooling import PooledMySQLConnection
 def retrieve_all_lightning_round_start(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> dict:
-    """Retrieve a dictionary of all Lightning Fill In The Blank round starting scores."""
+    """Retrieve a dictionary of all Lightning Fill In The Blank Segment starting scores."""
     if not database_connection.is_connected():
         database_connection.reconnect()
 

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -162,7 +162,7 @@ def retrieve_shows_all_low_scoring(
     """Retrieves details from shows with a panelist total score of less than 30.
 
     Excludes the 20th anniversary show due to unique Lightning
-    Fill-in-the-Blank segment.
+    Fill In The Blank segment.
     """
     if not database_connection.is_connected():
         database_connection.reconnect()
@@ -206,7 +206,7 @@ def retrieve_shows_panelist_score_sum_match(
     """Retrieves shows where a panelist's first place score matches the sum of the scores of the other two panelists.
 
     Excludes the 20th anniversary show due to unique Lightning
-    Fill-in-the-Blank segment.
+    Fill In The Blank segment.
     """
     if not database_connection.is_connected():
         database_connection.reconnect()

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -138,7 +138,7 @@ def highest_score_equals_sum_other_scores() -> str:
 
 @blueprint.route("/lightning-round-answering-same-number-correct")
 def lightning_round_answering_same_number_correct() -> str:
-    """View: Lightning Round Panelists Answering the Same Number of Questions Correct."""
+    """View: Lightning Fill In The Blank Panelists Answering the Same Number of Questions Correct."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_answering_same_number_correct(
         database_connection=_database_connection,
@@ -152,7 +152,7 @@ def lightning_round_answering_same_number_correct() -> str:
 
 @blueprint.route("/lightning-round-ending-three-way-tie")
 def lightning_round_ending_three_way_tie() -> str:
-    """View: Lightning Round Ending in a Three-Way Tie Report."""
+    """View: Lightning Fill In The Blank Ending in a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_ending_with_three_way_tie(
         database_connection=_database_connection,
@@ -166,7 +166,7 @@ def lightning_round_ending_three_way_tie() -> str:
 
 @blueprint.route("/lightning-round-starting-ending-three-way-tie")
 def lightning_round_starting_ending_three_way_tie() -> str:
-    """View: Lightning Round Starting and Ending in a Three-Way Tie Report."""
+    """View: Lightning Fill In The Blank Starting and Ending in a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_starting_ending_three_way_tie(
         database_connection=_database_connection,
@@ -180,7 +180,7 @@ def lightning_round_starting_ending_three_way_tie() -> str:
 
 @blueprint.route("/lightning-round-starting-three-way-tie")
 def lightning_round_starting_three_way_tie() -> str:
-    """View: Lightning Round Starting with a Three-Way Tie Report."""
+    """View: Lightning Fill In The Blank Starting with a Three-Way Tie Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_starting_with_three_way_tie(
         database_connection=_database_connection,
@@ -194,7 +194,7 @@ def lightning_round_starting_three_way_tie() -> str:
 
 @blueprint.route("/lightning-round-starting-zero-points")
 def lightning_round_starting_zero_points() -> str:
-    """View: Lightning Round Starting with Zero Points Report."""
+    """View: Lightning Fill In The Blank Starting with Zero Points Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_start_zero(
         database_connection=_database_connection,
@@ -208,7 +208,7 @@ def lightning_round_starting_zero_points() -> str:
 
 @blueprint.route("/lightning-round-zero-correct")
 def lightning_round_zero_correct() -> str:
-    """View: Lightning Round with Zero Correct Answers Report."""
+    """View: Lightning Fill In The Blank with Zero Correct Answers Report."""
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = shows_lightning_round_zero_correct(
         database_connection=_database_connection,

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -92,7 +92,7 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_answering_same_number_correct') }}">
-                        Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct
+                        Lightning Fill In The Blank: All Panelists Answering the Same Number of Questions Correct
                     </a>
                 </h3>
                 <div class="description">
@@ -161,7 +161,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A table displaying shows where a panelist started the Lightning Fill-in-the Blank segment
+                        A table displaying shows where a panelist started the Lightning Fill In The Blank segment
                         with zero points.
                     </p>
                     <p>
@@ -172,7 +172,7 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_zero_correct') }}">
-                        Lightning Fill In The Blank with Zero Correct Answers
+                        Lightning Fill In The Blank Segment with Zero Correct Answers
                     </a>
                 </h3>
                 <div class="description">

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -92,13 +92,13 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_answering_same_number_correct') }}">
-                        Lightning Round All Panelists Answering the Same Number of Questions Correct
+                        Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct
                     </a>
                 </h3>
                 <div class="description">
                     <p>
                         A table displaying shows where all three panelists answered the same number of Lightning
-                        Fill-in-the-Blank questions correct.
+                        Fill In The Blank questions correct.
                     </p>
                     <p>
                         Scoring from Best Of and repeat shows are not included.
@@ -108,13 +108,13 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_ending_three_way_tie') }}">
-                        Lightning Round Ending in a Three-Way Tie
+                        Lightning Fill In The Blank Ending in a Three-Way Tie
                     </a>
                 </h3>
                 <div class="description">
                     <p>
                         A table displaying shows where all three panelists finished the Lightning
-                        Fill-in-the-Blank segment in a three-way tie.
+                        Fill In The Blank segment in a three-way tie.
                     </p>
                     <p>
                         Scoring from Best Of and repeat shows are not included.
@@ -124,13 +124,13 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_starting_ending_three_way_tie') }}">
-                        Lightning Round Starting and Ending in a Three-Way Tie
+                        Lightning Fill In The Blank Starting and Ending in a Three-Way Tie
                     </a>
                 </h3>
                 <div class="description">
                     <p>
                         A table displaying shows where all three panelists started <em>and</em> finished the
-                        Lightning Fill-in-the-Blank segment in a three-way tie.
+                        Lightning Fill In The Blank segment in a three-way tie.
                     </p>
                     <p>
                         Scoring from Best Of and repeat shows are not included.
@@ -140,13 +140,13 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_starting_three_way_tie') }}">
-                        Lightning Round Starting in a Three-Way Tie
+                        Lightning Fill In The Blank Starting in a Three-Way Tie
                     </a>
                 </h3>
                 <div class="description">
                     <p>
                         A table displaying shows where all three panelists started the Lightning
-                        Fill-in-the-Blank segment in a three-way tie.
+                        Fill In The Blank segment in a three-way tie.
                     </p>
                     <p>
                         Scoring from Best Of and repeat shows are not included.
@@ -156,7 +156,7 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_starting_zero_points') }}">
-                        Lightning Round Starting with Zero Points
+                        Lightning Fill In The Blank Starting with Zero Points
                     </a>
                 </h3>
                 <div class="description">
@@ -172,12 +172,12 @@
             <li class="list-group-item">
                 <h3 class="title">
                     <a href="{{ url_for('shows.lightning_round_zero_correct') }}">
-                        Lightning Round with Zero Correct Answers
+                        Lightning Fill In The Blank with Zero Correct Answers
                     </a>
                 </h3>
                 <div class="description">
                     <p>
-                        A table displaying shows where a panelist did not answer any Lightning Fill-in-the-Blank
+                        A table displaying shows where a panelist did not answer any Lightning Fill In The Blank
                         questions correct, thus netting zero additional points.
                     </p>
                     <p>
@@ -199,7 +199,7 @@
                     <p>
                         Scoring from the 20th anniversary special that aired on
                         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> is not included
-                        due to the unique Lightning Fill-in-the-Blank format. Also, scoring from Best Of
+                        due to the unique Lightning Fill In The Blank format. Also, scoring from Best Of
                         and repeat shows are not included.
                     </p>
                 </div>
@@ -400,7 +400,7 @@
                 </h3>
                 <div class="description">
                     <p>
-                        A table displaying shows where a panelist finishes the Lightning Fill-in-the-Blank
+                        A table displaying shows where a panelist finishes the Lightning Fill In The Blank
                         segment with a total score of 20 points, a "perfect score" according to
                         scorekeeper Bill Kurtis.
                     </p>

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct" %}
+{% set page_title = "Lightning Fill In The Blank: All Panelists Answering the Same Number of Questions Correct" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round All Panelists Answering the Same Number of Questions Correct" %}
+{% set page_title = "Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying shows where all three panelists answered the same number of Lightning
-        Fill-in-the-Blank questions correct.
+        Fill In The Blank questions correct.
     </p>
     <p>
         Scoring from Best Of and repeat shows are not included.

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round Ending in a Three-Way Tie" %}
+{% set page_title = "Lightning Fill In The Blank Ending in a Three-Way Tie" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying shows where all three panelists finished the Lightning
-        Fill-in-the-Blank segment in a three-way tie.
+        Fill In The Blank segment in a three-way tie.
     </p>
     <p>
         Scoring from Best Of and repeat shows are not included.

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round Starting and Ending in a Three-Way Tie" %}
+{% set page_title = "Lightning Fill In The Blank Starting and Ending in a Three-Way Tie" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying shows where all three panelists started <em>and</em> finished the
-        Lightning Fill-in-the-Blank segment in a three-way tie.
+        Lightning Fill In The Blank segment in a three-way tie.
     </p>
     <p>
         Scoring from Best Of and repeat shows are not included.

--- a/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round Starting in a Three-Way Tie" %}
+{% set page_title = "Lightning Fill In The Blank Starting in a Three-Way Tie" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
@@ -14,7 +14,7 @@
     <h2>{{ page_title }}</h2>
     <p>
         A table displaying shows where all three panelists started the Lightning
-        Fill-in-the-Blank segment in a three-way tie.
+        Fill In The Blank segment in a three-way tie.
     </p>
     <p>
         Scoring from Best Of and repeat shows are not included.

--- a/app/shows/templates/shows/lightning-round-starting-zero-points.html
+++ b/app/shows/templates/shows/lightning-round-starting-zero-points.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round Starting with Zero Points" %}
+{% set page_title = "Lightning Fill In The Blank Starting with Zero Points" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Round with Zero Correct Answers" %}
+{% set page_title = "Lightning Fill In The Blank with Zero Correct Answers" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A table displaying shows where a panelist did not answer any Lightning Fill-in-the-Blank
+        A table displaying shows where a panelist did not answer any Lightning Fill In The Blank
         questions correct, thus netting zero additional points.
     </p>
     <p>

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set page_title = "Lightning Fill In The Blank with Zero Correct Answers" %}
+{% set page_title = "Lightning Fill In The Blank Segment with Zero Correct Answers" %}
 {% block title %}{{ page_title }} | Shows{% endblock %}
 
 {% block content %}

--- a/app/shows/templates/shows/low-scoring-shows.html
+++ b/app/shows/templates/shows/low-scoring-shows.html
@@ -19,7 +19,7 @@
     <p>
         Scoring from the 20th anniversary special that aired on
         <a href="{{ stats_url }}/shows/2018/10/27">October 27, 2018</a> is not included
-        due to the unique Lightning Fill-in-the-Blank format. Also, scoring from Best Of
+        due to the unique Lightning Fill In The Blank format. Also, scoring from Best Of
         and repeat shows are not included.
     </p>
 </div>

--- a/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
+++ b/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
@@ -13,7 +13,7 @@
 <div id="intro" class="mb-5">
     <h2>{{ page_title }}</h2>
     <p>
-        A table displaying shows where a panelist finishes the Lightning Fill-in-the-Blank
+        A table displaying shows where a panelist finishes the Lightning Fill In The Blank
         segment with a total score of 20 points, a "perfect score" according to
         scorekeeper Bill Kurtis.
     </p>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.3.2"
+APP_VERSION = "4.3.3"

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -74,7 +74,7 @@ def test_lightning_round_answering_same_number_correct(client: FlaskClient) -> N
     )
     assert response.status_code == 200
     assert (
-        b"Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct"
+        b"Lightning Fill In The Blank: All Panelists Answering the Same Number of Questions Correct"
         in response.data
     )
     assert b"Panelists" in response.data
@@ -126,7 +126,10 @@ def test_lightning_round_zero_correct(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_zero_correct."""
     response: TestResponse = client.get("/shows/lightning-round-zero-correct")
     assert response.status_code == 200
-    assert b"Lightning Fill In The Blank with Zero Correct Answers" in response.data
+    assert (
+        b"Lightning Fill In The Blank Segment with Zero Correct Answers"
+        in response.data
+    )
     assert b"Panelist" in response.data
     assert b"Rank" in response.data
 

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -74,7 +74,7 @@ def test_lightning_round_answering_same_number_correct(client: FlaskClient) -> N
     )
     assert response.status_code == 200
     assert (
-        b"Lightning Round All Panelists Answering the Same Number of Questions Correct"
+        b"Lightning Fill In The Blank All Panelists Answering the Same Number of Questions Correct"
         in response.data
     )
     assert b"Panelists" in response.data
@@ -85,7 +85,7 @@ def test_lightning_round_ending_three_way_tie(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_ending_three_way_tie."""
     response: TestResponse = client.get("/shows/lightning-round-ending-three-way-tie")
     assert response.status_code == 200
-    assert b"Lightning Round Ending in a Three-Way Tie" in response.data
+    assert b"Lightning Fill In The Blank Ending in a Three-Way Tie" in response.data
     assert b"Panelists" in response.data
     assert b"Final Score" in response.data
 
@@ -96,7 +96,10 @@ def test_lightning_round_starting_ending_three_way_tie(client: FlaskClient) -> N
         "/shows/lightning-round-starting-ending-three-way-tie"
     )
     assert response.status_code == 200
-    assert b"Lightning Round Starting and Ending in a Three-Way Tie" in response.data
+    assert (
+        b"Lightning Fill In The Blank Starting and Ending in a Three-Way Tie"
+        in response.data
+    )
     assert b"Panelists" in response.data
     assert b"Final Score" in response.data
 
@@ -105,7 +108,7 @@ def test_lightning_round_starting_three_way_tie(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_starting_three_way_tie."""
     response: TestResponse = client.get("/shows/lightning-round-starting-three-way-tie")
     assert response.status_code == 200
-    assert b"Lightning Round Starting in a Three-Way Tie" in response.data
+    assert b"Lightning Fill In The Blank Starting in a Three-Way Tie" in response.data
     assert b"Panelists" in response.data
     assert b"Starting Score" in response.data
 
@@ -114,7 +117,7 @@ def test_lightning_round_starting_zero_points(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_starting_zero_points."""
     response: TestResponse = client.get("/shows/lightning-round-starting-zero-points")
     assert response.status_code == 200
-    assert b"Lightning Round Starting with Zero Points" in response.data
+    assert b"Lightning Fill In The Blank Starting with Zero Points" in response.data
     assert b"Panelist" in response.data
     assert b"Rank" in response.data
 
@@ -123,7 +126,7 @@ def test_lightning_round_zero_correct(client: FlaskClient) -> None:
     """Testing shows.routes.lightning_round_zero_correct."""
     response: TestResponse = client.get("/shows/lightning-round-zero-correct")
     assert response.status_code == 200
-    assert b"Lightning Round with Zero Correct Answers" in response.data
+    assert b"Lightning Fill In The Blank with Zero Correct Answers" in response.data
     assert b"Panelist" in response.data
     assert b"Rank" in response.data
 


### PR DESCRIPTION
## Application Changes

- Standardized on the name "Lightning Fill In The Blank" for the segment, including:
  - Replaced all references of "Lightning Round" in report titles with "Lightning Fill In The Blank Segment"
  - Replaced "Fill-in-the-Blank" with "Fill In The Blank"
  - This does not change the name of the functions or variables