### PR TITLE
Add Panelists "First Appearance Answering All Lightning Questions Correct" report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.4.0
+
+### Application Changes
+
+- Added new Panelists "First Appearance Answering All Lightning Questions Correct" report that lists panelists who answered all eight (or nine for really early show) Lightning Fill In The Blank questions correct on their first appearance
+- Fixed logic for Panelists "First Appearance Wins" report in which an empty query result could lead to no or imcomplete data returned instead of skipping the empty result
+
 ## 4.3.3
 
 ### Application Changes

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -35,6 +35,9 @@ from .reports.bluff_stats import (
 )
 from .reports.common import retrieve_panelists
 from .reports.debut_by_year import panelist_debuts_by_year, retrieve_show_years
+from .reports.first_appearance_all_correct import (
+    retrieve_panelists_first_appearance_all_correct,
+)
 from .reports.first_appearance_wins import retrieve_panelists_first_appearance_wins
 from .reports.first_appearances import retrieve_panelists_first_appearance
 from .reports.first_wins import retrieve_panelists_first_wins
@@ -355,6 +358,21 @@ def debuts_by_year() -> str:
     _database_connection.close()
     return render_template(
         "panelists/debuts-by-year.html", years=_years, debuts=_debuts
+    )
+
+
+@blueprint.route("/first-appearance-all-correct")
+def first_appearance_all_correct() -> str:
+    """View: First Appearance Answering All Lightning Questions Correct Report."""
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _panelists = retrieve_panelists_first_appearance_all_correct(
+        database_connection=_database_connection,
+    )
+    _database_connection.close()
+    return render_template(
+        "panelists/first-appearance-all-correct.html",
+        panelists=_panelists,
+        rank_map=RANK_MAP,
     )
 
 

--- a/app/panelists/templates/panelists/_index.html
+++ b/app/panelists/templates/panelists/_index.html
@@ -202,6 +202,22 @@
             </li>
             <li class="list-group-item">
                 <h3 class="title">
+                    <a href="{{ url_for('panelists.first_appearance_all_correct') }}">
+                        First Appearance Answering All Lightning Questions Correct
+                    </a>
+                </h3>
+                <div class="description">
+                    <p>
+                        A table displaying panelists who answered all Lightning Fill In The Blank
+                        questions (eight in almost every single case) on their debut appearance.
+                        Information includes the show date, score at the start of the Lightning
+                        Fill In The Blank segment, the number of correct answers, total score,
+                        and ranking.
+                    </p>
+                </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
                     <a href="{{ url_for('panelists.first_appearance_wins') }}">
                         First Appearance Wins
                     </a>

--- a/app/panelists/templates/panelists/first-appearance-all-correct.html
+++ b/app/panelists/templates/panelists/first-appearance-all-correct.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% set page_title = "First Appearance Answering All Lightning Questions Correct" %}
+{% block title %}{{ page_title }} | Panelists{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('panelists.index') }}">Panelists</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        A table displaying panelists who answered all Lightning Fill In The Blank
+        questions (eight in almost every single case) on their debut appearance.
+        Information includes the show date, score at the start of the Lightning
+        Fill In The Blank segment, the number of correct answers, total score,
+        and ranking.
+    </p>
+</div>
+
+{% if panelists %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="name panelist">
+                    <col class="date">
+                    <col class="score">
+                    <col class="score">
+                    <col class="score">
+                    <col class="rank">
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th>Panelist</th>
+                        <th>Show Date</th>
+                        <th>Start</th>
+                        <th>Correct</th>
+                        <th>Total Score</th>
+                        <th>Rank</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for panelist in panelists %}
+                    {% set panelist_info = panelists[panelist] %}
+                    <tr>
+                        <td><a href="{{ stats_url }}/panelists/{{ panelist }}">{{ panelist_info.name }}</a></td>
+                        <td><a href="{{ stats_url }}/shows/{{ panelist_info.show_date | replace('-', '/') }}">{{ panelist_info.show_date }}</a></td>
+                        {% if panelist_info.start != None %}
+                        <td>{{ "{:f}".format(panelist_info.start.normalize()) }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if panelist_info.correct != None %}
+                        <td>{{ "{:f}".format(panelist_info.correct.normalize()) }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if panelist_info.score != None and panelist_info.rank %}
+                        <td>{{ "{:f}".format(panelist_info.score.normalize()) }}</td>
+                        <td>{{ rank_map[panelist_info.rank] }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        <td class="no-data">-</td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/sitemaps/templates/sitemaps/panelists.xml
+++ b/app/sitemaps/templates/sitemaps/panelists.xml
@@ -41,6 +41,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("panelists.first_appearance_all_correct") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("panelists.first_appearance_wins") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.3.3"
+APP_VERSION = "4.4.0"

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -164,6 +164,16 @@ def test_debuts_by_year(client: FlaskClient) -> None:
     assert b"# of Regular Appearances" in response.data
 
 
+def test_first_appearance_all_correct(client: FlaskClient) -> None:
+    """Testing panelists.first_appearance_all_correct."""
+    response: TestResponse = client.get("/panelists/first-appearance-all-correct")
+    assert response.status_code == 200
+    assert (
+        b"First Appearance Answering All Lightning Questions Correct" in response.data
+    )
+    assert b"Show Date" in response.data
+
+
 def test_first_appearance_wins(client: FlaskClient) -> None:
     """Testing panelists.first_appearance_wins."""
     response: TestResponse = client.get("/panelists/first-appearance-wins")


### PR DESCRIPTION
## Application Changes

- Added new Panelists "First Appearance Answering All Lightning Questions Correct" report that lists panelists who answered all eight (or nine for really early show) Lightning Fill In The Blank questions correct on their first appearance
- Fixed logic for Panelists "First Appearance Wins" report in which an empty query result could lead to no or imcomplete data returned instead of skipping the empty result