### PR TITLE
Update Flask and Ruff, make Python 3.12 minimum version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 4.6.0
+
+### Application Changes
+
+- Python 3.12 is now the minimum supported version of Python
+
+### Component Changes
+
+- Upgraded Flask from 3.1.1 to 3.1.2
+
+### Development Changes
+
+- Added project information in `pyproject.toml`
+- Upgraded Ruff from 0.12.8 to 0.13.3
+
 ## 4.5.0
 
 ### Application Changes

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ Flask-based web application that serves up a collection of reports based on coll
 
 ## Requirements
 
-- Python 3.10 or newer
-- MySQL Server 8.0 or newer (or another MySQL Server distribution based on MySQL Server 8.0 or newer) or MariaDB Server 11.4.2 or newer *(Experimental)*
+- Python 3.12 or newer
+- MySQL Server 8.0 or newer (or another MySQL Server distribution based on MySQL Server 8.0 or newer) or MariaDB Server 11.8 or newer *(Provisional)*
 
-**Note:** Experimental support for MariaDB Server is only available starting with version 2.10.0 of the application. Older versions of MariaDB Server are not supported.
-
-Also, due to potential incompatibilities with the divergence of MySQL and MariaDB, including the Python Connector libraries, support for MariaDB may not be feasible in the long term.
+**Note:** Provisional support for MariaDB Server is only available starting with version 2.10.0 of the application. Older versions of MariaDB Server are not supported.
 
 ## Installation
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.5.0"
+APP_VERSION = "4.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+name = "reports.wwdt.me"
+authors = [
+    {name = "Linh Pham", email = "dev@wwdt.me"}
+]
+description = "Wait Wait Reports Site"
+readme = {file = "README.md", content-type = "text/markdown"}
+license = "Apache-2.0"
+requires-python = ">=3.12"
+
 [tool.pytest.ini_options]
 minversion = "8.3"
 filterwarnings = ["ignore::DeprecationWarning:mysql.*:"]
@@ -5,7 +15,7 @@ norecursedirs = [".git", "venv", "dist", ".eggs", "wwdtm.egg-info"]
 
 [tool.ruff]
 required-version = ">= 0.9.0"
-target-version = "py310"
+target-version = "py312"
 
 exclude = [
     "migrations",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
-ruff==0.12.8
+ruff==0.13.3
 pytest==8.4.1
 pytest-cov==6.2.1
 
-Flask==3.1.1
+Flask==3.1.2
 Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 mysql-connector-python==9.1.0
-numpy==2.2.6
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.1.1
+Flask==3.1.2
 Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0


### PR DESCRIPTION
## Application Changes

- Python 3.12 is now the minimum supported version of Python

## Component Changes

- Upgraded Flask from 3.1.1 to 3.1.2

## Development Changes

- Added project information in `pyproject.toml`
- Upgraded Ruff from 0.12.8 to 0.13.3