### PR TITLE
Fix unhandled divide by zero error in "Wins, Draws and Losses" report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Application Changes
 
-- Fixed an issue where an unhandled divide by zero exception is thrown in the Panelists "Wins, Draws and Losses" report when a panelist has been added to the Stats Database but no appearances have been recorded for the panelist at the time the report is generated
+- Fixed an issue where an unhandled divide by zero exception is thrown in the Panelists "Wins, Draws and Losses" report when a panelist has been added to the Stats Database but no appearances have been recorded for the panelist at the time the report is generated. If a panelist does not have any recorded appearances, they will be included in the report but with zeroes for all values.
 
 ## 4.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 4.6.2
+
+### Application Changes
+
+- Fixed an issue where an unhandled divide by zero exception is thrown in the Panelists "Wins, Draws and Losses" report when a panelist has been added to the Stats Database but no appearances have been recorded for the panelist at the time the report is generated
+
 ## 4.6.1
 
 ### Component Changes

--- a/app/panelists/reports/wins_draws_losses.py
+++ b/app/panelists/reports/wins_draws_losses.py
@@ -78,15 +78,18 @@ def retrieve_panelist_wins_draws_losses(
     _losses = result["losses"]
     _total = result["wins"] + result["draws"] + result["losses"]
 
-    return {
-        "wins": _wins,
-        "wins_percent": round(Decimal((_wins / _total) * 100), 5),
-        "draws": _draws,
-        "draws_percent": round(Decimal((_draws / _total) * 100), 5),
-        "losses": _losses,
-        "losses_percent": round(Decimal((_losses / _total) * 100), 5),
-        "total": _total,
-    }
+    if _total:
+        return {
+            "wins": _wins,
+            "wins_percent": round(Decimal((_wins / _total) * 100), 5),
+            "draws": _draws,
+            "draws_percent": round(Decimal((_draws / _total) * 100), 5),
+            "losses": _losses,
+            "losses_percent": round(Decimal((_losses / _total) * 100), 5),
+            "total": _total,
+        }
+
+    return None
 
 
 def retrieve_all_wins_draws_losses(
@@ -120,17 +123,17 @@ def retrieve_all_wins_draws_losses(
                 "losses_percent": panelist_counts["losses_percent"],
                 "total": panelist_counts["total"],
             }
-        # else:
-        #     _counts[_panelist["slug"]] = {
-        #         "name": _panelist["name"],
-        #         "slug": _panelist["slug"],
-        #         "wins": 0,
-        #         "wins_percent": Decimal(0),
-        #         "draws": 0,
-        #         "draws_percent": Decimal(0),
-        #         "losses": 0,
-        #         "losses_percent": Decimal(0),
-        #         "total": 0,
-        #     }
+        else:
+            _counts[_panelist["slug"]] = {
+                "name": _panelist["name"],
+                "slug": _panelist["slug"],
+                "wins": 0,
+                "wins_percent": Decimal(0),
+                "draws": 0,
+                "draws_percent": Decimal(0),
+                "losses": 0,
+                "losses_percent": Decimal(0),
+                "total": 0,
+            }
 
     return _counts

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.6.1"
+APP_VERSION = "4.6.2"


### PR DESCRIPTION
## Application Changes

- Fixed an issue where an unhandled divide by zero exception is thrown in the Panelists "Wins, Draws and Losses" report when a panelist has been added to the Stats Database but no appearances have been recorded for the panelist at the time the report is generated