### PR TITLE
Remove unneeded aria-labelledby and update AI bots list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 4.9.1
+
+### Application Changes
+
+- Changed the behavior of the `block_ai_scrapers` settings flag to only include the list of blocked AI scrapers and the disallow statement in the rendered `robots.txt` file when set to `true`
+- Removed unnecessary `aria-labelledby` in the page navigation
+- Updated the list of AI bots in the `robots.txt` template to reflect the latest version published at [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt)
+
 ## 4.9.0
 
 ### Application Changes

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -11,9 +11,7 @@
             </button>
             <h1><a class="navbar-brand" href="{{ url_for('main.index') }}">Wait Wait Reports</a></h1>
 
-            <div class="offcanvas offcanvas-start" data-bs-scroll="true"
-                tabindex="-1" id="offcanvasNavbar"
-                aria-labelledby="offcanvasNavbarLabel">
+            <div class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="offcanvasNavbar">
                 <div class="offcanvas-header pb-0">
                     <h2 class="offcanvas-title" id="offcanvasNavbarLabel">Reports</h2>
                     <button class="btn-close btn-close-white" type="button"

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -6,19 +6,26 @@ Sitemap: {{ site_url }}{{ url_for("sitemaps.panelists") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.scorekeepers") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.shows") }}
 
+{% if block_ai_scrapers %}
 User-agent: AddSearchBot
 User-agent: AI2Bot
 User-agent: Ai2Bot-Dolma
 User-agent: aiHitBot
+User-agent: AmazonBuyForMe
+User-agent: atlassian-bot
+User-agent: amazon-kendra
 User-agent: Amazonbot
 User-agent: Andibot
+User-agent: Anomura
 User-agent: anthropic-ai
 User-agent: Applebot
 User-agent: Applebot-Extended
 User-agent: Awario
 User-agent: bedrockbot
 User-agent: bigsur.ai
+User-agent: Bravebot
 User-agent: Brightbot 1.0
+User-agent: BuddyBot
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ChatGPT Agent
@@ -27,12 +34,14 @@ User-agent: Claude-SearchBot
 User-agent: Claude-User
 User-agent: Claude-Web
 User-agent: ClaudeBot
+User-agent: Cloudflare-AutoRAG
 User-agent: CloudVertexBot
 User-agent: cohere-ai
 User-agent: cohere-training-data-crawler
 User-agent: Cotoyogi
 User-agent: Crawlspace
 User-agent: Datenbank Crawler
+User-agent: DeepSeekBot
 User-agent: Devin
 User-agent: Diffbot
 User-agent: DuckAssistBot
@@ -47,26 +56,32 @@ User-agent: Gemini-Deep-Research
 User-agent: Google-CloudVertexBot
 User-agent: Google-Extended
 User-agent: Google-Firebase
+User-agent: Google-NotebookLM
 User-agent: GoogleAgent-Mariner
 User-agent: GoogleOther
 User-agent: GoogleOther-Image
 User-agent: GoogleOther-Video
 User-agent: GPTBot
 User-agent: iaskspider/2.0
+User-agent: IbouBot
 User-agent: ICC-Crawler
 User-agent: ImagesiftBot
 User-agent: img2dataset
 User-agent: ISSCyberRiskCrawler
 User-agent: Kangaroo Bot
+User-agent: KlaviyoAIBot
 User-agent: LinerBot
+User-agent: Linguee Bot
 User-agent: meta-externalagent
 User-agent: Meta-ExternalAgent
 User-agent: meta-externalfetcher
 User-agent: Meta-ExternalFetcher
+User-agent: meta-webindexer
 User-agent: MistralAI-User
 User-agent: MistralAI-User/1.0
 User-agent: MyCentralAIScraperBot
 User-agent: netEstate Imprint Crawler
+User-agent: NotebookLM
 User-agent: NovaAct
 User-agent: OAI-SearchBot
 User-agent: omgili
@@ -90,6 +105,7 @@ User-agent: SemrushBot-OCOB
 User-agent: SemrushBot-SWA
 User-agent: ShapBot
 User-agent: Sidetrade indexer bot
+User-agent: TerraCotta
 User-agent: Thinkbot
 User-agent: TikTokSpider
 User-agent: Timpibot
@@ -101,10 +117,7 @@ User-agent: YaK
 User-agent: YandexAdditional
 User-agent: YandexAdditionalBot
 User-agent: YouBot
-{% if block_ai_scrapers %}
 Disallow: /
-{% else %}
-Crawl-delay: 10
 {% endif %}
 
 User-agent: *

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.9.0"
+APP_VERSION = "4.9.1"


### PR DESCRIPTION
## Application Changes

- Changed the behavior of the `block_ai_scrapers` settings flag to only include the list of blocked AI scrapers and the disallow statement in the rendered `robots.txt` file when set to `true`
- Removed unnecessary `aria-labelledby` in the page navigation
- Updated the list of AI bots in the `robots.txt` template to reflect the latest version published at [ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt)