### PR TITLE
New Best Of Shows with Unique Bluff report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.10.0
+
+### Application Changes
+
+- Added a new Shows "Best Of Shows with Unique Bluff the Listener Segments" report that lists Best Of shows that have a Bluff the Listener segment that has not been included in a regular show. This usually happens when the show has a second recording when traveling away from Chicago. The report includes the name of the panelist with the chosen Bluff story and the name of the panelist with the correct Bluff story
+- Corrected docstring for `app.shows.routes.best_of_shows()`, `app.shows.routes.repeat_best_of_shows()` and `app.shows.routes.repeat_shows()` to reflect the correct report name
+
 ## 4.9.2
 
 ### Application Changes
@@ -491,7 +498,7 @@ Due to the significant changes around the new application theming, the usual App
 #### Guests
 
 | Original Report Name | Original Report URL | New Report Name (if applicable) | New Report URL |
-|----------------------|---------------------|-----------------|----------------|
+| -------------------- | ------------------- | --------------- | -------------- |
 | Best Of Not My Job Guests | `/guests/best-of-only` | N/A | `/guests/best-of-only-not-my-job-guests` |
 | Not My Job Scoring Exceptions | `/guests/scoring-exceptions` | N/A | `/guests/not-my-job-scoring-exceptions` |
 | Not My Job Three Pointers | `/guests/three-pointers` | N/A | `/guests/not-my-job-three-pointers` |
@@ -499,13 +506,13 @@ Due to the significant changes around the new application theming, the usual App
 #### Locations
 
 | Original Report Name | Original Report URL | New Report Name (if applicable) | New Report URL |
-|----------------------|---------------------|-----------------|----------------|
+| -------------------- | ------------------- | --------------- | -------------- |
 | Average Score by Location | `/locations/average-scores` | Average Scores by Location | `/locations/average-scores-by-location` |
 
 #### Panelists
 
 | Original Report Name | Original Report URL | New Report Name (if applicable) | New Report URL |
-|----------------------|---------------------|-----------------|----------------|
+| -------------------- | ------------------- | --------------- | -------------- |
 | Bluff the Listener Statistics | `/panelists/bluff-stats` | N/A | `/panelists/bluff-the-listener-statistics` |
 | Bluff the Listener Statistics by Year | `/panelists/bluff-stats-by-year` | N/A | `/panelists/bluff-the-listener-statistics-by-year` |
 | Debut by Year | `/panelists/debut-by-year` | Debuts by Year | `/panelists/debuts-by-year` |
@@ -518,13 +525,13 @@ Due to the significant changes around the new application theming, the usual App
 #### Scorekeepers
 
 | Original Report Name | Original Report URL | New Report Name (if applicable) | New Report URL |
-|----------------------|---------------------|-----------------|----------------|
+| -------------------- | ------------------- | --------------- | -------------- |
 | Introductions | `/scorekeepers/introductions` | Scorekeeper Introductions | `/scorekeepers/scorekeeper-introductions` |
 
 #### Shows
 
 | Original Report Name | Original Report URL | New Report Name (if applicable) | New Report URL |
-|----------------------|---------------------|-----------------|----------------|
+| -------------------- | ------------------- | --------------- | -------------- |
 | High Scoring Shows | `/shows/high-scoring` | N/A | `/shows/high-scoring-shows` |
 | Low Scoring Shows | `/shows/low-scoring` | N/A | `/shows/low-scoring-shows` |
 | Not My Job Guests vs Bluff the Listener Win Ratios | `/shows/not-my-job-vs-bluffs` | N/A | `/shows/not-my-job-guests-vs-bluff-the-listener-win-ratios` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -939,7 +939,7 @@ Due to the significant changes around the new application theming, the usual App
 - Changed section names from singular to plural to match the naming convention used by the Wait Wait Stats Page, Wait Wait API and Wait Wait Graphs applications:
 
 | v1 Section Name | v2 Section Name |
-|-----------------|-----------------|
+| --------------- | --------------- |
 | guest           | guests          |
 | host            | hosts           |
 | location        | locations       |
@@ -956,7 +956,7 @@ Due to the significant changes around the new application theming, the usual App
 - Standardize column widths across all reports
 - Redesign the Panelist vs Panelist report use the same base temlate as other reports
 - Enable Markdown handling for show notes fields in the respective reports
-- Display `-` for table cells containing no data
+- Display a hyphen for table cells containing no data
 - Change MySQL Connector cursor return type from `dict` to `NamedTuple` where applicable
 
 ### Development Changes

--- a/app/shows/reports/unique_best_of_bluff.py
+++ b/app/shows/reports/unique_best_of_bluff.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2018-2025 Linh Pham
+# reports.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""WWDTM Unique Best Of Bluff the Listener Segments Report Functions."""
+
+from curses import panel
+from typing import Any
+
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
+from app.panelists.reports.common import retrieve_panelists_id_key
+
+from .show_details import retrieve_show_date_by_id
+
+
+def retrieve_unique_best_of_bluff_shows(
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[dict[str, Any]]:
+    """Retrieves a list of Best Of shows with a unique Bluff the Listener Segment."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT s.showdate, s.repeatshowid, blm.segment, blm.chosenbluffpnlid,
+        blm.correctbluffpnlid
+        FROM ww_showbluffmap blm
+        JOIN ww_shows s ON s.showid = blm.showid
+        WHERE s.bestof = 1 AND s.bestofuniquebluff = 1
+        ORDER BY s.showdate ASC;
+    """
+    cursor = database_connection.cursor(dictionary=True)
+    cursor.execute(query)
+    results = cursor.fetchall()
+    cursor.close()
+
+    if not results:
+        return None
+
+    panelists = retrieve_panelists_id_key(database_connection=database_connection)
+    shows = []
+
+    for row in results:
+        _repeat_show = bool(row["repeatshowid"])
+        shows.append(
+            {
+                "date": row["showdate"].isoformat(),
+                "repeat": _repeat_show,
+                "original_show_date": retrieve_show_date_by_id(row["repeatshowid"])
+                if _repeat_show
+                else None,
+                "bluff_segment": row["segment"],
+                "chosen_bluff": panelists[row["chosenbluffpnlid"]]
+                if row["chosenbluffpnlid"]
+                else None,
+                "correct_bluff": panelists[row["correctbluffpnlid"]]
+                if row["correctbluffpnlid"]
+                else None,
+            }
+        )
+
+    return shows

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -48,6 +48,9 @@ from .reports.show_details import (
 )
 from .reports.show_details import retrieve_all_repeat_shows as details_repeat_shows
 from .reports.show_details import retrieve_all_shows as details_all_shows
+from .reports.unique_best_of_bluff import (
+    retrieve_unique_best_of_bluff_shows as unique_bluff_shows,
+)
 
 blueprint = Blueprint("shows", __name__, template_folder="templates")
 
@@ -104,7 +107,7 @@ def all_women_panel() -> str:
 
 @blueprint.route("/best-of-shows")
 def best_of_shows() -> str:
-    """View: All Shows Report."""
+    """View: Best Of Shows Report."""
     _ascending = True
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = details_best_of_shows(database_connection=_database_connection)
@@ -121,6 +124,30 @@ def best_of_shows() -> str:
 
     return render_template(
         "shows/best-of-shows.html", shows=_shows, ascending=_ascending
+    )
+
+
+@blueprint.route("/best-of-shows-with-unique-bluff-segments")
+def best_of_shows_with_unique_bluff() -> str:
+    """View: Best Of Shows with Unique Bluff the Listener Segments Report."""
+    _ascending = True
+    _database_connection = mysql.connector.connect(**current_app.config["database"])
+    _shows = unique_bluff_shows(database_connection=_database_connection)
+    _database_connection.close()
+
+    if "sort" in request.args:
+        _sort = str(request.args["sort"])
+
+        if _sort.lower() == "desc":
+            _ascending = False
+
+    if not _ascending:
+        _shows.reverse()
+
+    return render_template(
+        "shows/best-of-shows-with-unique-bluff-segments.html",
+        shows=_shows,
+        ascending=_ascending,
     )
 
 
@@ -298,7 +325,7 @@ def panel_gender_mix() -> str:
 
 @blueprint.route("/repeat-best-of-shows")
 def repeat_best_of_shows() -> str:
-    """View: All Shows Report."""
+    """View: Repeat Best Of Shows Report."""
     _ascending = True
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = details_repeat_best_of_shows(database_connection=_database_connection)
@@ -320,7 +347,7 @@ def repeat_best_of_shows() -> str:
 
 @blueprint.route("/repeat-shows")
 def repeat_shows() -> str:
-    """View: All Shows Report."""
+    """View: Repeat Shows Report."""
     _ascending = True
     _database_connection = mysql.connector.connect(**current_app.config["database"])
     _shows = details_repeat_shows(database_connection=_database_connection)

--- a/app/shows/templates/shows/_index.html
+++ b/app/shows/templates/shows/_index.html
@@ -71,6 +71,19 @@
             </li>
             <li class="list-group-item">
                 <h3 class="title">
+                    <a href="{{ url_for('shows.best_of_shows_with_unique_bluff') }}">
+                        Best Of Shows with Unique Bluff the Listener Segments
+                    </a>
+                </h3>
+                <div class="description">
+                    <p>
+                        A table displaying all of the unique Bluff the Listener segments that have
+                        only aired as part of Best Of shows.
+                    </p>
+                </div>
+            </li>
+            <li class="list-group-item">
+                <h3 class="title">
                     <a href="{{ url_for('shows.high_scoring_shows') }}">
                         High Scoring Shows
                     </a>

--- a/app/shows/templates/shows/best-of-shows-with-unique-bluff-segments.html
+++ b/app/shows/templates/shows/best-of-shows-with-unique-bluff-segments.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% set page_title = "Best Of Shows with Unique Bluff the Listener Segments" %}
+{% block title %}{{ page_title }} | Shows{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb" id="nav-breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+    </ol>
+</nav>
+
+<div id="intro" class="mb-5">
+    <h2>{{ page_title }}</h2>
+    <p>
+        A table displaying all of the unique Bluff the Listener segments that have
+        only aired as part of Best Of shows.
+    </p>
+</div>
+
+{% if shows %}
+<div class="row">
+    <div class="col-auto">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover report">
+                <colgroup>
+                    <col class="date">
+                    <col class="date">
+                    <col class="count label">
+                    <col class="name panelist">
+                    <col class="name panelist">
+                </colgroup>
+                <thead>
+                    <tr>
+                        {% if ascending %}
+                        <th scope="col">
+                            <a href="{{ url_for('shows.best_of_shows_with_unique_bluff', sort='desc') }}">
+                                Date <i class="bi bi-sort-down-alt ms-1" title="Change sorting to descending"></i>
+                            </a>
+                        </th>
+                        {% else %}
+                        <th scope="col">
+                            <a href="{{ url_for('shows.best_of_shows_with_unique_bluff') }}">
+                                Date <i class="bi bi-sort-down ms-1" title="Change sorting to ascending"></i>
+                            </a>
+                        </th>
+                        {% endif %}
+                        <th scope="col">Repeat Of</th>
+                        <th scope="col">Bluff Segment #</th>
+                        <th scope="col">Chosen</th>
+                        <th scope="col">Correct</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for show in shows %}
+                    <tr>
+                        <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        {% if show.repeat and show.original_show_date is not none %}
+                        <td><a href="{{ stats_url }}/shows/{{ show.original_show_date | replace('-', '/') }}">{{ show.original_show_date }}</a></td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        <td>{{ show.bluff_segment }}</td>
+                        {% if show.chosen_bluff and show.chosen_bluff is not none %}
+                        <td><a href="{{ stats_url }}/panelists/{{ show.chosen_bluff.slug }}">{{ show.chosen_bluff.name }}</a></td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                        {% if show.correct_bluff and show.correct_bluff is not none %}
+                        <td><a href="{{ stats_url }}/panelists/{{ show.correct_bluff.slug }}">{{ show.correct_bluff.name }}</a></td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col">Date</th>
+                        <th scope="col">Repeat Of</th>
+                        <th scope="col">Bluff Segment #</th>
+                        <th scope="col">Chosen</th>
+                        <th scope="col">Correct</th>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="alert alert-info my-5" role="alert">
+    <i class="bi bi-info-circle pe-1"></i> Data for <b>{{ page_title }}</b> is currently unavailable.
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/app/sitemaps/templates/sitemaps/shows.xml
+++ b/app/sitemaps/templates/sitemaps/shows.xml
@@ -17,6 +17,10 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>{{ site_url }}{{ url_for("shows.best_of_shows_with_unique_bluff") }}</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
     <loc>{{ site_url }}{{ url_for("shows.high_scoring_shows") }}</loc>
     <changefreq>weekly</changefreq>
   </url>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.9.2"
+APP_VERSION = "4.10.0"

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -57,6 +57,18 @@ def test_best_of_shows(client: FlaskClient, sort: str | None) -> None:
     assert b"Guest" in response.data
 
 
+@pytest.mark.parametrize("sort", [None, "asc", "desc"])
+def test_best_of_shows_with_unique_bluff(client: FlaskClient, sort: str | None) -> None:
+    """Testing shows.routes.best_of_shows_with_unique_bluff."""
+    response: TestResponse = client.get(
+        "/shows/best-of-shows-with-unique-bluff-segments", query_string={"sort": sort}
+    )
+    assert response.status_code == 200
+    assert b"Best Of Shows with Unique Bluff the Listener Segments" in response.data
+    assert b"Change sorting to" in response.data
+    assert b"Bluff Segment #" in response.data
+
+
 def test_high_scoring_shows(client: FlaskClient) -> None:
     """Testing shows.routes.high_scoring_shows."""
     response: TestResponse = client.get("/shows/high-scoring-shows")


### PR DESCRIPTION
## Application Changes

- Added a new Shows "Best Of Shows with Unique Bluff the Listener Segments" report that lists Best Of shows that have a Bluff the Listener segment that has not been included in a regular show. This usually happens when the show has a second recording when traveling away from Chicago. The report includes the name of the panelist with the chosen Bluff story and the name of the panelist with the correct Bluff story
- Corrected docstring for `app.shows.routes.best_of_shows()`, `app.shows.routes.repeat_best_of_shows()` and `app.shows.routes.repeat_shows()` to reflect the correct report name