### PR TITLE
Fix divide-by-zero error in Bluff vs NMJ win ratios report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.10.1
+
+### Application Changes
+
+- Changed the "Win %" columns in the "Not My Job Guests vs Bluff the Listener Win Ratios by Year" report to display a hyphen instead of zero
+- Fixed a divide-by-zero error that occurs in the "Not My Job Guests vs Bluff the Listener Win Ratios by Year" report when there aren't any Bluff the Listener or Not My Job data for a given year
+
 ## 4.10.0
 
 ### Application Changes

--- a/app/shows/reports/guests_vs_bluffs_by_year.py
+++ b/app/shows/reports/guests_vs_bluffs_by_year.py
@@ -146,18 +146,23 @@ def retrieve_not_my_job_stats_by_year(
                 elif result["guestscore"] < 2 and not bool(result["exception"]):
                     best_of_only_guest_losses += 1
 
-    _stats = {
-        "total": count_all_guest_scores + len(best_of_only_guest_ids),
-        "wins": count_guest_wins + best_of_only_guest_wins,
-        "losses": count_guest_losses + best_of_only_guest_losses,
-        "win_ratio": round(
+    if count_all_guest_scores or best_of_only_guest_ids:
+        win_ratio = round(
             100
             * (
                 (count_guest_wins + best_of_only_guest_wins)
                 / (count_all_guest_scores + len(best_of_only_guest_ids))
             ),
             5,
-        ),
+        )
+    else:
+        win_ratio = 0
+
+    _stats = {
+        "total": count_all_guest_scores + len(best_of_only_guest_ids),
+        "wins": count_guest_wins + best_of_only_guest_wins,
+        "losses": count_guest_losses + best_of_only_guest_losses,
+        "win_ratio": win_ratio,
     }
 
     return _stats
@@ -245,11 +250,15 @@ def retrieve_bluff_stats_by_year(
 
     count_chosen_incorrect = result[0]
 
+    if count_unique_bluffs:
+        correct_ratio = round(100 * (count_chosen_correct / count_unique_bluffs), 5)
+    else:
+        correct_ratio = 0
     return {
         "total": count_unique_bluffs,
         "correct": count_chosen_correct,
         "incorrect": count_chosen_incorrect,
-        "correct_ratio": round(100 * (count_chosen_correct / count_unique_bluffs), 5),
+        "correct_ratio": correct_ratio,
     }
 
 

--- a/app/shows/templates/shows/not-my-job-guests-vs-bluff-the-listener-win-ratios.html
+++ b/app/shows/templates/shows/not-my-job-guests-vs-bluff-the-listener-win-ratios.html
@@ -78,12 +78,20 @@
                         <td>{{ stats[year].not_my_job.wins }}</td>
                         <td>{{ stats[year].not_my_job.losses }}</td>
                         <td>{{ stats[year].not_my_job.total }}</td>
+                        {% if stats[year].not_my_job.win_ratio %}
                         <td>{{ stats[year].not_my_job.win_ratio }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
                         <td class="filled">&nbsp;</td>
                         <td>{{ stats[year].bluff.correct }}</td>
                         <td>{{ stats[year].bluff.incorrect }}</td>
                         <td>{{ stats[year].bluff.total }}</td>
+                        {% if stats[year].bluff.correct_ratio %}
                         <td>{{ stats[year].bluff.correct_ratio }}</td>
+                        {% else %}
+                        <td class="no-data">-</td>
+                        {% endif %}
                     </tr>
                     {% endif %}
                 {% endfor %}

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.10.0"
+APP_VERSION = "4.10.1"


### PR DESCRIPTION
## Application Changes

- Changed the "Win %" columns in the "Not My Job Guests vs Bluff the Listener Win Ratios by Year" report to display a hyphen instead of zero
- Fixed a divide-by-zero error that occurs in the "Not My Job Guests vs Bluff the Listener Win Ratios by Year" report when there aren't any Bluff the Listener or Not My Job data for a given year