### PR TITLE
Add Scorekeeper column to Lightning Fill In The Blank series of reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added "Scorekeeper" column to the series of Lightning Fill In The Blank reports within the Shows section of the site
 - Added table footers that were missing in several of the Lightning Fill In The Blank reports
+- Removed the unused `app.shows.reports.shows_with_lightning_round_start_zero()` function
 
 ## 4.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 4.15.0
+
+### Application Changes
+
+- Added "Scorekeeper" column to the series of Lightning Fill In The Blank reports within the Shows section of the site
+- Added table footers that were missing in several of the Lightning Fill In The Blank reports
+
 ## 4.14.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added "Scorekeeper" column to the series of Lightning Fill In The Blank reports within the Shows section of the site
 - Added table footers that were missing in several of the Lightning Fill In The Blank reports
+- Changed the score column widths for Lightning Fill In The Blank reports to be more consistent and prevent text wrapping
 - Removed the unused `app.shows.reports.shows_with_lightning_round_start_zero()` function
 
 ## 4.14.0

--- a/app/scorekeepers/reports/appearances.py
+++ b/app/scorekeepers/reports/appearances.py
@@ -174,3 +174,34 @@ def retrieve_appearance_summaries(
         }
 
     return scorekeepers_summary
+
+
+def retrieve_scorekeeper_by_show_id(
+    show_id: int,
+    database_connection: MySQLConnection | PooledMySQLConnection,
+) -> list[dict]:
+    """Returns scorekeeper information for the requested show ID."""
+    if not database_connection.is_connected():
+        database_connection.reconnect()
+
+    query = """
+        SELECT sk.scorekeeperid, sk.scorekeeper, sk.scorekeeperslug
+        FROM ww_showskmap skm
+        JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid
+        JOIN ww_shows s ON s.showid = skm.showid
+        WHERE s.showid = %s
+        LIMIT 1;
+    """
+    cursor = database_connection.cursor(dictionary=True)
+    cursor.execute(query, (show_id,))
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return {
+        "id": result["scorekeeperid"],
+        "name": result["scorekeeper"],
+        "slug": result["scorekeeperslug"],
+    }

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -130,55 +130,6 @@ def retrieve_panelists_by_show_id(
     return panelists
 
 
-def shows_with_lightning_round_start_zero(
-    database_connection: MySQLConnection | PooledMySQLConnection,
-) -> list[dict]:
-    """Return shows in which panelists start Lightning Fill In The Blank with zero points."""
-    if not database_connection.is_connected():
-        database_connection.reconnect()
-
-    query = """
-        SELECT s.showid, s.showdate, p.panelistid, p.panelist,
-        pm.panelistlrndstart_decimal, pm.panelistlrndcorrect_decimal,
-        pm.panelistscore_decimal, pm.showpnlrank
-        FROM ww_showpnlmap pm
-        JOIN ww_shows s ON s.showid = pm.showid
-        JOIN ww_panelists p ON p.panelistid = pm.panelistid
-        WHERE s.bestof = 0 AND s.repeatshowid IS NULL
-        AND pm.panelistlrndstart_decimal = 0
-        ORDER BY s.showdate ASC;
-    """
-    cursor = database_connection.cursor(dictionary=True)
-    cursor.execute(query)
-    result = cursor.fetchall()
-    cursor.close()
-
-    if not result:
-        return None
-
-    shows = []
-    for row in result:
-        shows.append(
-            {
-                "id": row["showid"],
-                "date": row["showdate"].isoformat(),
-                "scorekeeper": retrieve_scorekeeper_by_show_id(
-                    show_id=row["showid"], database_connection=database_connection
-                ),
-                "panelist": {
-                    "id": row["panelistid"],
-                    "name": row["panelist"],
-                    "start": row["panelistlrndstart_decimal"],
-                    "correct": row["panelistlrndcorrect_decimal"],
-                    "score": row["panelistscore_decimal"],
-                    "rank": row["showpnlrank"],
-                },
-            }
-        )
-
-    return shows
-
-
 def shows_lightning_round_start_zero(
     database_connection: MySQLConnection | PooledMySQLConnection,
 ) -> list[dict]:

--- a/app/shows/reports/lightning_round.py
+++ b/app/shows/reports/lightning_round.py
@@ -9,6 +9,8 @@
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 
+from app.scorekeepers.reports.appearances import retrieve_scorekeeper_by_show_id
+
 
 def retrieve_all_lightning_round_start(
     database_connection: MySQLConnection | PooledMySQLConnection,
@@ -160,6 +162,9 @@ def shows_with_lightning_round_start_zero(
             {
                 "id": row["showid"],
                 "date": row["showdate"].isoformat(),
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelist": {
                     "id": row["panelistid"],
                     "name": row["panelist"],
@@ -206,6 +211,9 @@ def shows_lightning_round_start_zero(
             {
                 "id": row["showid"],
                 "date": row["showdate"].isoformat(),
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelist": {
                     "id": row["panelistid"],
                     "name": row["panelist"],
@@ -251,6 +259,9 @@ def shows_lightning_round_zero_correct(
             {
                 "id": row["showid"],
                 "date": row["showdate"].isoformat(),
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelist": {
                     "id": row["panelistid"],
                     "name": row["panelist"],
@@ -303,6 +314,9 @@ def shows_lightning_round_answering_same_number_correct(
             {
                 "id": row["showid"],
                 "date": row["showdate"].isoformat(),
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelists": panelists,
                 "correct_decimal": row["panelistlrndcorrect_decimal"],
             }
@@ -329,6 +343,9 @@ def shows_starting_with_three_way_tie(
                 {
                     "id": show_id,
                     "date": show_date,
+                    "scorekeeper": retrieve_scorekeeper_by_show_id(
+                        show_id=show_id, database_connection=database_connection
+                    ),
                     "score": show_scores[show]["scores"][0],
                     "panelists": retrieve_panelists_by_show_id(
                         show_id=show_id, database_connection=database_connection
@@ -372,6 +389,9 @@ def shows_ending_with_three_way_tie(
             {
                 "id": row["showid"],
                 "date": row["showdate"].isoformat(),
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "score": row["panelistscore_decimal"],
                 "panelists": retrieve_panelists_by_show_id(
                     show_id=row["showid"], database_connection=database_connection
@@ -420,6 +440,9 @@ def shows_starting_ending_three_way_tie(
                 {
                     "id": show_id,
                     "date": score_info["date"],
+                    "scorekeeper": retrieve_scorekeeper_by_show_id(
+                        show_id=show_id, database_connection=database_connection
+                    ),
                     "panelists": retrieve_panelists_by_show_id(
                         show_id=show_id, database_connection=database_connection
                     ),

--- a/app/shows/reports/scoring.py
+++ b/app/shows/reports/scoring.py
@@ -11,6 +11,8 @@ from decimal import Decimal
 from mysql.connector.connection import MySQLConnection
 from mysql.connector.pooling import PooledMySQLConnection
 
+from app.scorekeepers.reports.appearances import retrieve_scorekeeper_by_show_id
+
 
 def retrieve_show_details(
     show_id: int,
@@ -212,7 +214,7 @@ def retrieve_shows_panelist_score_sum_match(
         database_connection.reconnect()
 
     query = """
-        SELECT s.showdate, pm.panelistid, p.panelist, p.panelistslug,
+        SELECT s.showid, s.showdate, pm.panelistid, p.panelist, p.panelistslug,
         pm.panelistscore_decimal, pm.showpnlrank
         FROM ww_showpnlmap pm
         JOIN ww_shows s ON s.showid = pm.showid
@@ -238,6 +240,9 @@ def retrieve_shows_panelist_score_sum_match(
 
         shows[show_date].append(
             {
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelist_id": row["panelistid"],
                 "panelist": row["panelist"],
                 "panelist_slug": row["panelistslug"],
@@ -269,7 +274,7 @@ def retrieve_shows_panelist_perfect_scores(
         database_connection.reconnect()
 
     query = """
-        SELECT s.showdate, p.panelist, p.panelistslug, pm.panelistscore_decimal
+        SELECT s.showid, s.showdate, p.panelist, p.panelistslug, pm.panelistscore_decimal
         FROM ww_showpnlmap pm
         JOIN ww_shows s ON s.showid = pm.showid
         JOIN ww_panelists p ON p.panelistid = pm.panelistid
@@ -289,6 +294,9 @@ def retrieve_shows_panelist_perfect_scores(
         shows.append(
             {
                 "date": row["showdate"],
+                "scorekeeper": retrieve_scorekeeper_by_show_id(
+                    show_id=row["showid"], database_connection=database_connection
+                ),
                 "panelist": row["panelist"],
                 "panelist_slug": row["panelistslug"],
                 "score": row["panelistscore_decimal"],

--- a/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
+++ b/app/shows/templates/shows/highest-score-equals-sum-other-scores.html
@@ -28,6 +28,7 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                     <col class="rank">
@@ -35,6 +36,7 @@
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Score</th>
                         <th scope="col">Rank</th>
@@ -44,6 +46,7 @@
                     {% for show in shows %}
                     <tr>
                         <td rowspan="3"><a href="{{ stats_url }}/shows/{{ show | replace('-', '/') }}">{{ show }}</a></td>
+                        <td rowspan="3">{{ shows[show][0]["scorekeeper"]["name"] }}</td>
                         <td>{{ shows[show][0]["panelist"] }}</td>
                         <td>{{ "{:f}".format(shows[show][0]["score"].normalize()) }}</td>
                         <td>{{ rank_map[shows[show][0]["rank"]] }}</td>
@@ -63,6 +66,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Score</th>
                         <th scope="col">Rank</th>

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -28,12 +28,14 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                 </colgroup>
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Correct Answers</th>
                     </tr>
@@ -42,6 +44,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>
                             <ul class="no-bullets">
                                 {% for panelist in show.panelists %}
@@ -57,6 +60,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Correct Answers</th>
                     </tr>

--- a/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
+++ b/app/shows/templates/shows/lightning-round-answering-same-number-correct.html
@@ -30,7 +30,7 @@
                     <col class="date">
                     <col class="name scorekeeper">
                     <col class="name panelist">
-                    <col class="score">
+                    <col class="score long">
                 </colgroup>
                 <thead>
                     <tr>

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -28,12 +28,14 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                 </colgroup>
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Final Score</th>
                     </tr>
@@ -42,6 +44,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>
                             <ul class="no-bullets">
                                 {% for panelist in show.panelists %}
@@ -57,6 +60,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Final Score</th>
                     </tr>

--- a/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-ending-three-way-tie.html
@@ -28,9 +28,9 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
-                    <col class="scorekeeper">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
-                    <col class="score">
+                    <col class="score long">
                 </colgroup>
                 <thead>
                     <tr>

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -28,6 +28,7 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                     <col class="score">
@@ -36,6 +37,7 @@
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Starting Score</th>
                         <th scope="col">Correct</th>
@@ -46,6 +48,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>
                             <ul class="no-bullets">
                                 {% for panelist in show.panelists %}
@@ -63,6 +66,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Starting Score</th>
                         <th scope="col">Correct</th>

--- a/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-ending-three-way-tie.html
@@ -30,9 +30,9 @@
                     <col class="date">
                     <col class="name scorekeeper">
                     <col class="name panelist">
-                    <col class="score">
-                    <col class="score">
-                    <col class="score">
+                    <col class="score long">
+                    <col class="score long">
+                    <col class="score long">
                 </colgroup>
                 <thead>
                     <tr>

--- a/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
@@ -28,12 +28,14 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                 </colgroup>
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Starting Score</th>
                     </tr>
@@ -42,6 +44,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>
                             <ul class="no-bullets">
                                 {% for panelist in show.panelists %}
@@ -57,6 +60,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelists</th>
                         <th scope="col">Starting Score</th>
                     </tr>

--- a/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
+++ b/app/shows/templates/shows/lightning-round-starting-three-way-tie.html
@@ -30,7 +30,7 @@
                     <col class="date">
                     <col class="name scorekeeper">
                     <col class="name panelist">
-                    <col class="score">
+                    <col class="score long">
                 </colgroup>
                 <thead>
                     <tr>

--- a/app/shows/templates/shows/lightning-round-starting-zero-points.html
+++ b/app/shows/templates/shows/lightning-round-starting-zero-points.html
@@ -28,6 +28,7 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                     <col class="score">
@@ -37,6 +38,7 @@
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Start</th>
                         <th scope="col">Correct</th>
@@ -48,6 +50,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>{{ show.panelist.name }}</td>
                         <td>{{ "{:f}".format(show.panelist.start.normalize()) }}</td>
                         <td>{{ "{:f}".format(show.panelist.correct.normalize()) }}</td>
@@ -59,6 +62,7 @@
                 <tfoot>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Start</th>
                         <th scope="col">Correct</th>

--- a/app/shows/templates/shows/lightning-round-zero-correct.html
+++ b/app/shows/templates/shows/lightning-round-zero-correct.html
@@ -28,6 +28,7 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                     <col class="score">
@@ -37,6 +38,7 @@
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Start</th>
                         <th scope="col">Correct</th>
@@ -48,6 +50,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>{{ show.panelist.name }}</td>
                         <td>{{ "{:f}".format(show.panelist.start.normalize()) }}</td>
                         <td>{{ "{:f}".format(show.panelist.correct.normalize()) }}</td>
@@ -56,6 +59,17 @@
                     </tr>
                     {% endfor %}
                 </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
+                        <th scope="col">Panelist</th>
+                        <th scope="col">Start</th>
+                        <th scope="col">Correct</th>
+                        <th scope="col">Score</th>
+                        <th scope="col">Rank</th>
+                    </tr>
+                </tfoot>
             </table>
         </div>
     </div>

--- a/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
+++ b/app/shows/templates/shows/shows-with-perfect-panelist-scores.html
@@ -34,12 +34,14 @@
             <table class="table table-bordered table-hover report">
                 <colgroup>
                     <col class="date">
+                    <col class="name scorekeeper">
                     <col class="name panelist">
                     <col class="score">
                 </colgroup>
                 <thead>
                     <tr>
                         <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
                         <th scope="col">Panelist</th>
                         <th scope="col">Total Score</th>
                     </tr>
@@ -48,6 +50,7 @@
                     {% for show in shows %}
                     <tr>
                         <td><a href="{{ stats_url }}/shows/{{ show.date | replace('-', '/') }}">{{ show.date }}</a></td>
+                        <td>{{ show.scorekeeper.name }}</td>
                         <td>{{ show.panelist }}</td>
                         {% if show.score > 20 %}
                         <td><b>{{ "{:f}".format(show.score.normalize()) }}</b></td>
@@ -57,6 +60,14 @@
                     </tr>
                     {% endfor %}
                 </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col">Show Date</th>
+                        <th scope="col">Scorekeeper</th>
+                        <th scope="col">Panelist</th>
+                        <th scope="col">Total Score</th>
+                    </tr>
+                </tfoot>
             </table>
         </div>
     </div>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Version module for Wait Wait Reports."""
 
-APP_VERSION = "4.14.0"
+APP_VERSION = "4.15.0"

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -48,8 +48,9 @@ def test_recordings_by_year(client: FlaskClient) -> None:
 @pytest.mark.parametrize(
     "location_slug",
     [
-        "studebaker-theater-chicago-il",
         "arlene-schnitzer-concert-hall-portland-or",
+        "home-remote-studios",
+        "studebaker-theater-chicago-il",
     ],
 )
 def test_recordings_by_year_post(client: FlaskClient, location_slug: str) -> None:


### PR DESCRIPTION
## Application Changes

- Added "Scorekeeper" column to the series of Lightning Fill In The Blank reports within the Shows section of the site
- Added table footers that were missing in several of the Lightning Fill In The Blank reports
- Changed the score column widths for Lightning Fill In The Blank reports to be more consistent and prevent text wrapping
- Removed the unused `app.shows.reports.shows_with_lightning_round_start_zero()` function